### PR TITLE
Add destination display values

### DIFF
--- a/AJS37.json
+++ b/AJS37.json
@@ -1,6100 +1,7234 @@
 {
-            "Countermeasures": {
-                                   "COUNTERMEASURE_CHAFF_FLARES_SELECTOR": {
-                                                                                          "category": "Countermeasures",
-                                                                                      "control_type": "selector",
-                                                                                       "description": "Countermeasure Chaff/Flares Selector",
-                                                                                        "identifier": "COUNTERMEASURE_CHAFF_FLARES_SELECTOR",
-                                                                                            "inputs": [ {
-                                                                                                          "description": "switch to previous or next state",
-                                                                                                            "interface": "fixed_step"
-                                                                                                      }, {
-                                                                                                          "description": "set position",
-                                                                                                            "interface": "set_state",
-                                                                                                            "max_value": 2
-                                                                                                      } ],
-                                                                               "momentary_positions": "none",
-                                                                                           "outputs": [ {
-                                                                                                              "address": 17944,
-                                                                                                          "description": "selector position",
-                                                                                                                 "mask": 192,
-                                                                                                            "max_value": 2,
-                                                                                                             "shift_by": 6,
-                                                                                                               "suffix": "",
-                                                                                                                 "type": "integer"
-                                                                                                      } ],
-                                                                                  "physical_variant": "limited_rotary"
-                                                                           },
-                                           "COUNTERMEASURE_MODE_SELECTOR": {
-                                                                                          "category": "Countermeasures",
-                                                                                      "control_type": "selector",
-                                                                                       "description": "Countermeasure Operation Mode Selector",
-                                                                                        "identifier": "COUNTERMEASURE_MODE_SELECTOR",
-                                                                                            "inputs": [ {
-                                                                                                          "description": "switch to previous or next state",
-                                                                                                            "interface": "fixed_step"
-                                                                                                      }, {
-                                                                                                          "description": "set position",
-                                                                                                            "interface": "set_state",
-                                                                                                            "max_value": 4
-                                                                                                      } ],
-                                                                               "momentary_positions": "none",
-                                                                                           "outputs": [ {
-                                                                                                              "address": 17944,
-                                                                                                          "description": "selector position",
-                                                                                                                 "mask": 56,
-                                                                                                            "max_value": 4,
-                                                                                                             "shift_by": 3,
-                                                                                                               "suffix": "",
-                                                                                                                 "type": "integer"
-                                                                                                      } ],
-                                                                                  "physical_variant": "limited_rotary"
-                                                                           },
-                                            "COUNTERMEASURE_RELEASE_MODE": {
-                                                                                          "category": "Countermeasures",
-                                                                                      "control_type": "selector",
-                                                                                       "description": "Countermeasure Release Mode",
-                                                                                        "identifier": "COUNTERMEASURE_RELEASE_MODE",
-                                                                                            "inputs": [ {
-                                                                                                          "description": "switch to previous or next state",
-                                                                                                            "interface": "fixed_step"
-                                                                                                      }, {
-                                                                                                          "description": "set position",
-                                                                                                            "interface": "set_state",
-                                                                                                            "max_value": 2
-                                                                                                      } ],
-                                                                               "momentary_positions": "none",
-                                                                                           "outputs": [ {
-                                                                                                              "address": 17944,
-                                                                                                          "description": "selector position",
-                                                                                                                 "mask": 768,
-                                                                                                            "max_value": 2,
-                                                                                                             "shift_by": 8,
-                                                                                                               "suffix": "",
-                                                                                                                 "type": "integer"
-                                                                                                      } ],
-                                                                                  "physical_variant": "limited_rotary"
-                                                                           },
-                                    "COUNTERMEASURE_STREAK_MODE_SELECTOR": {
-                                                                                          "category": "Countermeasures",
-                                                                                      "control_type": "selector",
-                                                                                       "description": "Countermeasure Streak Mode Selector",
-                                                                                        "identifier": "COUNTERMEASURE_STREAK_MODE_SELECTOR",
-                                                                                            "inputs": [ {
-                                                                                                          "description": "switch to previous or next state",
-                                                                                                            "interface": "fixed_step"
-                                                                                                      }, {
-                                                                                                          "description": "set position",
-                                                                                                            "interface": "set_state",
-                                                                                                            "max_value": 1
-                                                                                                      }, {
-                                                                                                             "argument": "TOGGLE",
-                                                                                                          "description": "Toggle switch state",
-                                                                                                            "interface": "action"
-                                                                                                      } ],
-                                                                               "momentary_positions": "none",
-                                                                                           "outputs": [ {
-                                                                                                              "address": 17942,
-                                                                                                          "description": "selector position",
-                                                                                                                 "mask": 16384,
-                                                                                                            "max_value": 1,
-                                                                                                             "shift_by": 14,
-                                                                                                               "suffix": "",
-                                                                                                                 "type": "integer"
-                                                                                                      } ],
-                                                                                  "physical_variant": "limited_rotary"
-                                                                           },
-                                                   "JAMMER_BAND_SELECTOR": {
-                                                                                          "category": "Countermeasures",
-                                                                                      "control_type": "selector",
-                                                                                       "description": "Jammer Band Selector",
-                                                                                        "identifier": "JAMMER_BAND_SELECTOR",
-                                                                                            "inputs": [ {
-                                                                                                          "description": "switch to previous or next state",
-                                                                                                            "interface": "fixed_step"
-                                                                                                      }, {
-                                                                                                          "description": "set position",
-                                                                                                            "interface": "set_state",
-                                                                                                            "max_value": 4
-                                                                                                      } ],
-                                                                               "momentary_positions": "none",
-                                                                                           "outputs": [ {
-                                                                                                              "address": 17944,
-                                                                                                          "description": "selector position",
-                                                                                                                 "mask": 7,
-                                                                                                            "max_value": 4,
-                                                                                                             "shift_by": 0,
-                                                                                                               "suffix": "",
-                                                                                                                 "type": "integer"
-                                                                                                      } ],
-                                                                                  "physical_variant": "limited_rotary"
-                                                                           },
-                                                   "JAMMER_MODE_SELECTOR": {
-                                                                                          "category": "Countermeasures",
-                                                                                      "control_type": "selector",
-                                                                                       "description": "Jammer Mode Selector",
-                                                                                        "identifier": "JAMMER_MODE_SELECTOR",
-                                                                                            "inputs": [ {
-                                                                                                          "description": "switch to previous or next state",
-                                                                                                            "interface": "fixed_step"
-                                                                                                      }, {
-                                                                                                          "description": "set position",
-                                                                                                            "interface": "set_state",
-                                                                                                            "max_value": 4
-                                                                                                      } ],
-                                                                               "momentary_positions": "none",
-                                                                                           "outputs": [ {
-                                                                                                              "address": 17942,
-                                                                                                          "description": "selector position",
-                                                                                                                 "mask": 14336,
-                                                                                                            "max_value": 4,
-                                                                                                             "shift_by": 11,
-                                                                                                               "suffix": "",
-                                                                                                                 "type": "integer"
-                                                                                                      } ],
-                                                                                  "physical_variant": "limited_rotary"
-                                                                           }
-                               },
-                    "Doppler": {
-                                   "DOPPLER_LAND_SEA_MODE": {
-                                                                           "category": "Doppler",
-                                                                       "control_type": "action",
-                                                                        "description": "Doppler Land/Sea Mode",
-                                                                         "identifier": "DOPPLER_LAND_SEA_MODE",
-                                                                             "inputs": [ {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 17936,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 2,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 1,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "limited_rotary"
-                                                            }
-                               },
-            "Electric System": {
-                                      "BACKUP_GENERATOR": {
-                                                                         "category": "Electric System",
-                                                                     "control_type": "selector",
-                                                                      "description": "Backup Generator",
-                                                                       "identifier": "BACKUP_GENERATOR",
-                                                                           "inputs": [ {
-                                                                                         "description": "switch to previous or next state",
-                                                                                           "interface": "fixed_step"
-                                                                                     }, {
-                                                                                         "description": "set position",
-                                                                                           "interface": "set_state",
-                                                                                           "max_value": 1
-                                                                                     }, {
-                                                                                            "argument": "TOGGLE",
-                                                                                         "description": "Toggle switch state",
-                                                                                           "interface": "action"
-                                                                                     } ],
-                                                              "momentary_positions": "none",
-                                                                          "outputs": [ {
-                                                                                             "address": 17934,
-                                                                                         "description": "selector position",
-                                                                                                "mask": 32768,
-                                                                                           "max_value": 1,
-                                                                                            "shift_by": 15,
-                                                                                              "suffix": "",
-                                                                                                "type": "integer"
-                                                                                     } ],
-                                                                 "physical_variant": "toggle_switch"
-                                                          },
-                                             "GENERATOR": {
-                                                                         "category": "Electric System",
-                                                                     "control_type": "selector",
-                                                                      "description": "Generator",
-                                                                       "identifier": "GENERATOR",
-                                                                           "inputs": [ {
-                                                                                         "description": "switch to previous or next state",
-                                                                                           "interface": "fixed_step"
-                                                                                     }, {
-                                                                                         "description": "set position",
-                                                                                           "interface": "set_state",
-                                                                                           "max_value": 1
-                                                                                     }, {
-                                                                                            "argument": "TOGGLE",
-                                                                                         "description": "Toggle switch state",
-                                                                                           "interface": "action"
-                                                                                     } ],
-                                                              "momentary_positions": "none",
-                                                                          "outputs": [ {
-                                                                                             "address": 17934,
-                                                                                         "description": "selector position",
-                                                                                                "mask": 8192,
-                                                                                           "max_value": 1,
-                                                                                            "shift_by": 13,
-                                                                                              "suffix": "",
-                                                                                                "type": "integer"
-                                                                                     } ],
-                                                                 "physical_variant": "toggle_switch"
-                                                          },
-                                   "MAIN_ELECTRIC_POWER": {
-                                                                         "category": "Electric System",
-                                                                     "control_type": "selector",
-                                                                      "description": "Main Electric Power",
-                                                                       "identifier": "MAIN_ELECTRIC_POWER",
-                                                                           "inputs": [ {
-                                                                                         "description": "switch to previous or next state",
-                                                                                           "interface": "fixed_step"
-                                                                                     }, {
-                                                                                         "description": "set position",
-                                                                                           "interface": "set_state",
-                                                                                           "max_value": 1
-                                                                                     }, {
-                                                                                            "argument": "TOGGLE",
-                                                                                         "description": "Toggle switch state",
-                                                                                           "interface": "action"
-                                                                                     } ],
-                                                              "momentary_positions": "none",
-                                                                          "outputs": [ {
-                                                                                             "address": 17934,
-                                                                                         "description": "selector position",
-                                                                                                "mask": 16384,
-                                                                                           "max_value": 1,
-                                                                                            "shift_by": 14,
-                                                                                              "suffix": "",
-                                                                                                "type": "integer"
-                                                                                     } ],
-                                                                 "physical_variant": "toggle_switch"
-                                                          }
-                               },
-               "Engine Panel": {
-                                                "AFK_LEVER": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "AFK Lever",
-                                                                          "identifier": "AFK_LEVER",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17934,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 1024,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 10,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "limited_rotary"
-                                                             },
-                                          "CABIN_AIR_VALVE": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "Cabin Air Valve",
-                                                                          "identifier": "CABIN_AIR_VALVE",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 18076,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 1,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 0,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                             "CB_AUTOPILOT": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "CB Autopilot SA",
-                                                                          "identifier": "CB_AUTOPILOT",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17926,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 4096,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 12,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                                 "CB_CI_SI": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "CB CI/SI",
-                                                                          "identifier": "CB_CI_SI",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17926,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 32768,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 15,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                       "CB_EJECTION_SYSTEM": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "CB Ejection System",
-                                                                          "identifier": "CB_EJECTION_SYSTEM",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17934,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 1,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 0,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                                "CB_ENGINE": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "CB Engine",
-                                                                          "identifier": "CB_ENGINE",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17934,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 2,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 1,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                       "CB_HIGH_ALPHA_WARN": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "CB High Alpha Warning",
-                                                                          "identifier": "CB_HIGH_ALPHA_WARN",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17926,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 8192,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 13,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                           "CB_TRIM_SYSTEM": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "CB Trim System",
-                                                                          "identifier": "CB_TRIM_SYSTEM",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17926,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 16384,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 14,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                           "DATA_CARTRIDGE": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "Insert/Remove Data Cartridge",
-                                                                          "identifier": "DATA_CARTRIDGE",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17934,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 2048,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 11,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                                   "DE-ICE": {
-                                                                     "category": "Engine Panel",
-                                                                 "control_type": "limited_dial",
-                                                                  "description": "Windscreen De-Ice",
-                                                                   "identifier": "DE-ICE",
-                                                                       "inputs": [ {
-                                                                                     "description": "set the position of the dial",
-                                                                                       "interface": "set_state",
-                                                                                       "max_value": 65535
-                                                                                 }, {
-                                                                                        "description": "turn the dial left or right",
-                                                                                          "interface": "variable_step",
-                                                                                          "max_value": 65535,
-                                                                                     "suggested_step": 3200
-                                                                                 } ],
-                                                                      "outputs": [ {
-                                                                                         "address": 18070,
-                                                                                     "description": "position of the potentiometer",
-                                                                                            "mask": 65535,
-                                                                                       "max_value": 65535,
-                                                                                        "shift_by": 0,
-                                                                                          "suffix": "",
-                                                                                            "type": "integer"
-                                                                                 } ]
-                                                             },
-                                             "DME_SELECTOR": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "DME Selector",
-                                                                          "identifier": "DME_SELECTOR",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17934,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 16,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 4,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                                  "DRYSUIT": {
-                                                                     "category": "Engine Panel",
-                                                                 "control_type": "limited_dial",
-                                                                  "description": "Drysuit Ventilation Adjustment",
-                                                                   "identifier": "DRYSUIT",
-                                                                       "inputs": [ {
-                                                                                     "description": "set the position of the dial",
-                                                                                       "interface": "set_state",
-                                                                                       "max_value": 65535
-                                                                                 }, {
-                                                                                        "description": "turn the dial left or right",
-                                                                                          "interface": "variable_step",
-                                                                                          "max_value": 65535,
-                                                                                     "suggested_step": 3200
-                                                                                 } ],
-                                                                      "outputs": [ {
-                                                                                         "address": 18074,
-                                                                                     "description": "position of the potentiometer",
-                                                                                            "mask": 65535,
-                                                                                       "max_value": 65535,
-                                                                                        "shift_by": 0,
-                                                                                          "suffix": "",
-                                                                                            "type": "integer"
-                                                                                 } ]
-                                                             },
-                                             "ENGINE_DEICE": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "Engine De-Ice",
-                                                                          "identifier": "ENGINE_DEICE",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17926,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 1024,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 10,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                          "FLIGHT_RECORDER": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "Flight Recorder",
-                                                                          "identifier": "FLIGHT_RECORDER",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 2
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17934,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 384,
-                                                                                              "max_value": 2,
-                                                                                               "shift_by": 7,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "limited_rotary"
-                                                             },
-                                     "HIGH_PRES_FUEL_VALVE": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "High Pressure Fuel Valve",
-                                                                          "identifier": "HIGH_PRES_FUEL_VALVE",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17926,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 512,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 9,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                              "IFF_CHANNEL": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "IFF Channel Selector",
-                                                                          "identifier": "IFF_CHANNEL",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17934,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 8,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 3,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                    "IFF_TRANSPONDER_POWER": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "IFF/Transponder Power",
-                                                                          "identifier": "IFF_TRANSPONDER_POWER",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17934,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 4,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 2,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                          "IGNITION_SYSTEM": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "Ignition System",
-                                                                          "identifier": "IGNITION_SYSTEM",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17934,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 32,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 5,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                      "LOW_PRES_FUEL_VALVE": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "Low Pressure Fuel Valve",
-                                                                          "identifier": "LOW_PRES_FUEL_VALVE",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17926,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 256,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 8,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                          "MANUAL_FUEL_REG": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "Manual Fuel Regulator",
-                                                                          "identifier": "MANUAL_FUEL_REG",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17926,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 2048,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 11,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                   "MAN_AFTERBURN_FUEL_REG": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "Manual Afterburner Fuel Regulator",
-                                                                          "identifier": "MAN_AFTERBURN_FUEL_REG",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17934,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 64,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 6,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                    "MISSILE_SELECT_BUTTON": {
-                                                                         "api_variant": "momentary_last_position",
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "Missile Select Button",
-                                                                          "identifier": "MISSILE_SELECT_BUTTON",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17934,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 4096,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 12,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "push_button"
-                                                             },
-                                                  "RESTART": {
-                                                                         "api_variant": "momentary_last_position",
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "Restart",
-                                                                          "identifier": "RESTART",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17934,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 512,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 9,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "push_button"
-                                                             },
-                                             "START_SYSTEM": {
-                                                                            "category": "Engine Panel",
-                                                                        "control_type": "selector",
-                                                                         "description": "Start System",
-                                                                          "identifier": "START_SYSTEM",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17926,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 128,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 7,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                                "TEST_MODE": {
-                                                                     "category": "Engine Panel",
-                                                                 "control_type": "limited_dial",
-                                                                  "description": "Maintenance Testing Mode",
-                                                                   "identifier": "TEST_MODE",
-                                                                       "inputs": [ {
-                                                                                     "description": "set the position of the dial",
-                                                                                       "interface": "set_state",
-                                                                                       "max_value": 65535
-                                                                                 }, {
-                                                                                        "description": "turn the dial left or right",
-                                                                                          "interface": "variable_step",
-                                                                                          "max_value": 65535,
-                                                                                     "suggested_step": 3200
-                                                                                 } ],
-                                                                      "outputs": [ {
-                                                                                         "address": 18072,
-                                                                                     "description": "position of the potentiometer",
-                                                                                            "mask": 65535,
-                                                                                       "max_value": 65535,
-                                                                                        "shift_by": 0,
-                                                                                          "suffix": "",
-                                                                                            "type": "integer"
-                                                                                 } ]
-                                                             }
-                               },
-                "Error Panel": {
-                                      "AFK_FEL": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Autothrottle",
-                                                       "identifier": "AFK_FEL",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18028,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 4096,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 12,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                      "BRAND_1": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Engine Fire 1",
-                                                       "identifier": "BRAND_1",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 17944,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 8192,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 13,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                      "BRAND_2": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Engine Fire 2",
-                                                       "identifier": "BRAND_2",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 17944,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 16384,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 14,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                    "BRAND_GTS": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Turbine Starter Fire",
-                                                       "identifier": "BRAND_GTS",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18030,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 2048,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 11,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                       "BRA_24": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Low Fuel",
-                                                       "identifier": "BRA_24",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18030,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 1024,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 10,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                     "BRA_UPPF": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Fuel Distribution Low Pressure",
-                                                       "identifier": "BRA_UPPF",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 17944,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 32768,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 15,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                           "CK": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Computer",
-                                                       "identifier": "CK",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18030,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 8,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 3,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                       "EJ_REV": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Thrust Reverser Inoperable",
-                                                       "identifier": "EJ_REV",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18028,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 8192,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 13,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                        "ELFEL": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Electrical System",
-                                                       "identifier": "ELFEL",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18028,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 256,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 8,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                     "FACKL_SL": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Flares Empty",
-                                                       "identifier": "FACKL_SL",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18032,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 1,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 0,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                    "FORV_FORB": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Thrust Reverser Warning",
-                                                       "identifier": "FORV_FORB",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18028,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 8,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 3,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                    "HALL_FUNK": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Autopilot Hold",
-                                                       "identifier": "HALL_FUNK",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18030,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 1,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 0,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                       "HSTALL": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Right Gear",
-                                                       "identifier": "HSTALL",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18028,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 64,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 6,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                   "HUV_O_STOL": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Ejection Seat/Canopy",
-                                                       "identifier": "HUV_O_STOL",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18030,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 32,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 5,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                   "HYDRA_TA_1": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Hydraulic System 1 Pressure",
-                                                       "identifier": "HYDRA_TA_1",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18028,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 2048,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 11,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                   "HYDRA_TA_2": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Hydraulic System 2 Pressure",
-                                                       "identifier": "HYDRA_TA_2",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18028,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 1024,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 10,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                    "KABINHOJD": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Cabin Pressure",
-                                                       "identifier": "KABINHOJD",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18030,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 16,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 4,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                   "KB_H_KA_SL": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Right Countermeasures Pod Empty/ECM Failure",
-                                                       "identifier": "KB_H_KA_SL",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18030,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 32768,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 15,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                    "KB_V_SLUT": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Left Countermeasures Pod Empty",
-                                                       "identifier": "KB_V_SLUT",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18030,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 16384,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 14,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                    "LANDSTALL": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Landing Gear",
-                                                       "identifier": "LANDSTALL",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18028,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 4,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 2,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                    "LUFTBROMS": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Airbrakes",
-                                                       "identifier": "LUFTBROMS",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18032,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 4,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 2,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                   "MAN_BG_REG": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Manual Fuel Regulator",
-                                                       "identifier": "MAN_BG_REG",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18030,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 256,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 8,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                      "MOTVERK": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Countermeasures/RWR",
-                                                       "identifier": "MOTVERK",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18032,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 2,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 1,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                     "NAV_SYST": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Navigation System",
-                                                       "identifier": "NAV_SYST",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18030,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 8192,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 13,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                     "NOSSTALL": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Nose Gear",
-                                                       "identifier": "NOSSTALL",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18028,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 16,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 4,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                    "OLJETRYCK": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Oil Pressure",
-                                                       "identifier": "OLJETRYCK",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18028,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 16384,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 14,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                    "RESERVEFF": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Backup Hydraulic",
-                                                       "identifier": "RESERVEFF",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18028,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 512,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 9,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                      "RHM_FEL": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Radar Altimeter",
-                                                       "identifier": "RHM_FEL",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18030,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 2,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 1,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                   "ROLL_VAXEL": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Roll Gearing",
-                                                       "identifier": "ROLL_VAXEL",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18030,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 4,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 2,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                   "SPAK_ERROR": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "SPAK Error",
-                                                       "identifier": "SPAK_ERROR",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18028,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 32768,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 15,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                    "STARTSYST": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Starter System",
-                                                       "identifier": "STARTSYST",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18030,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 128,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 7,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                       "SYRGAS": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Oxygen",
-                                                       "identifier": "SYRGAS",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18030,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 512,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 9,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                     "TANDSYST": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Ignition System",
-                                                       "identifier": "TANDSYST",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18030,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 64,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 6,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                    "TANK_PUMP": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Fuel Pump",
-                                                       "identifier": "TANK_PUMP",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18028,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 2,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 1,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                         "TILS": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "TILS",
-                                                       "identifier": "TILS",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18030,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 4096,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 12,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                    "TIPPVAXEL": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Pitch Gearing",
-                                                       "identifier": "TIPPVAXEL",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18028,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 128,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 7,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                       "VSTALL": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "Left Gear",
-                                                       "identifier": "VSTALL",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18028,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 32,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 5,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 },
-                                   "X_TANK_BRA": {
-                                                         "category": "Error Panel",
-                                                     "control_type": "led",
-                                                      "description": "External Fuel Tank Feed System",
-                                                       "identifier": "X_TANK_BRA",
-                                                           "inputs": [  ],
-                                                          "outputs": [ {
-                                                                             "address": 18028,
-                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                "mask": 1,
-                                                                           "max_value": 1,
-                                                                            "shift_by": 0,
-                                                                              "suffix": "",
-                                                                                "type": "integer"
-                                                                     } ]
-                                                 }
-                               },
-    "External Aircraft Model": {
-                                    "EXT_FORMATION_LIGHTS": {
-                                                                    "category": "External Aircraft Model",
-                                                                "control_type": "metadata",
-                                                                 "description": "Formation Lights",
-                                                                  "identifier": "EXT_FORMATION_LIGHTS",
-                                                                      "inputs": [  ],
-                                                                     "outputs": [ {
-                                                                                        "address": 18032,
-                                                                                    "description": "Formation Lights",
-                                                                                           "mask": 128,
-                                                                                      "max_value": 1,
-                                                                                       "shift_by": 7,
-                                                                                         "suffix": "",
-                                                                                           "type": "integer"
-                                                                                } ]
-                                                            },
-                                     "EXT_NAV_LIGHTS_TAIL": {
-                                                                    "category": "External Aircraft Model",
-                                                                "control_type": "metadata",
-                                                                 "description": "Navigation Lights Tail",
-                                                                  "identifier": "EXT_NAV_LIGHTS_TAIL",
-                                                                      "inputs": [  ],
-                                                                     "outputs": [ {
-                                                                                        "address": 18032,
-                                                                                    "description": "Navigation Lights Tail",
-                                                                                           "mask": 32,
-                                                                                      "max_value": 1,
-                                                                                       "shift_by": 5,
-                                                                                         "suffix": "",
-                                                                                           "type": "integer"
-                                                                                } ]
-                                                            },
-                                     "EXT_NAV_LIGHTS_WING": {
-                                                                    "category": "External Aircraft Model",
-                                                                "control_type": "metadata",
-                                                                 "description": "Navigation Lights Wing",
-                                                                  "identifier": "EXT_NAV_LIGHTS_WING",
-                                                                      "inputs": [  ],
-                                                                     "outputs": [ {
-                                                                                        "address": 18032,
-                                                                                    "description": "Navigation Lights Wing",
-                                                                                           "mask": 16,
-                                                                                      "max_value": 1,
-                                                                                       "shift_by": 4,
-                                                                                         "suffix": "",
-                                                                                           "type": "integer"
-                                                                                } ]
-                                                            },
-                                     "EXT_POSITION_LIGHTS": {
-                                                                    "category": "External Aircraft Model",
-                                                                "control_type": "metadata",
-                                                                 "description": "Position Lights",
-                                                                  "identifier": "EXT_POSITION_LIGHTS",
-                                                                      "inputs": [  ],
-                                                                     "outputs": [ {
-                                                                                        "address": 18032,
-                                                                                    "description": "Position Lights",
-                                                                                           "mask": 8,
-                                                                                      "max_value": 1,
-                                                                                       "shift_by": 3,
-                                                                                         "suffix": "",
-                                                                                           "type": "integer"
-                                                                                } ]
-                                                            },
-                                    "EXT_SPEED_BRAKE_LEFT": {
-                                                                    "category": "External Aircraft Model",
-                                                                "control_type": "metadata",
-                                                                 "description": "Left Speed Brake",
-                                                                  "identifier": "EXT_SPEED_BRAKE_LEFT",
-                                                                      "inputs": [  ],
-                                                                     "outputs": [ {
-                                                                                        "address": 18052,
-                                                                                    "description": "Left Speed Brake",
-                                                                                           "mask": 65535,
-                                                                                      "max_value": 65535,
-                                                                                       "shift_by": 0,
-                                                                                         "suffix": "",
-                                                                                           "type": "integer"
-                                                                                } ]
-                                                            },
-                                   "EXT_SPEED_BRAKE_RIGHT": {
-                                                                    "category": "External Aircraft Model",
-                                                                "control_type": "metadata",
-                                                                 "description": "Right Speed Brake",
-                                                                  "identifier": "EXT_SPEED_BRAKE_RIGHT",
-                                                                      "inputs": [  ],
-                                                                     "outputs": [ {
-                                                                                        "address": 18050,
-                                                                                    "description": "Right Speed Brake",
-                                                                                           "mask": 65535,
-                                                                                      "max_value": 65535,
-                                                                                       "shift_by": 0,
-                                                                                         "suffix": "",
-                                                                                           "type": "integer"
-                                                                                } ]
-                                                            },
-                                       "EXT_STROBE_LIGHTS": {
-                                                                    "category": "External Aircraft Model",
-                                                                "control_type": "metadata",
-                                                                 "description": "Strobe Lights",
-                                                                  "identifier": "EXT_STROBE_LIGHTS",
-                                                                      "inputs": [  ],
-                                                                     "outputs": [ {
-                                                                                        "address": 18032,
-                                                                                    "description": "Strobe Lights",
-                                                                                           "mask": 64,
-                                                                                      "max_value": 1,
-                                                                                       "shift_by": 6,
-                                                                                         "suffix": "",
-                                                                                           "type": "integer"
-                                                                                } ]
-                                                            }
-                               },
-                 "FR22 Radio": {
-                                               "FR22_BASE": {
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "FR22 Base Selector",
-                                                                         "identifier": "FR22_BASE",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 10
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18066,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 120,
-                                                                                             "max_value": 10,
-                                                                                              "shift_by": 3,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "limited_rotary"
-                                                            },
-                                         "FR22_CHANNEL_AG": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Channel A/G",
-                                                                         "identifier": "FR22_CHANNEL_AG",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18064,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 1024,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 10,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                          "FR22_CHANNEL_B": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Channel B",
-                                                                         "identifier": "FR22_CHANNEL_B",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18064,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 2048,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 11,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                         "FR22_CHANNEL_C2": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Channel C2",
-                                                                         "identifier": "FR22_CHANNEL_C2",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18064,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 8192,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 13,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                         "FR22_CHANNEL_CF": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Channel C/F",
-                                                                         "identifier": "FR22_CHANNEL_CF",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18064,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 4096,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 12,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                         "FR22_CHANNEL_DE": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Channel D/E",
-                                                                         "identifier": "FR22_CHANNEL_DE",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18064,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 16384,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 14,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                          "FR22_CHANNEL_H": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Channel H",
-                                                                         "identifier": "FR22_CHANNEL_H",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18064,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 32,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 5,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                           "FR22_FLIGHT_0": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Flight 0",
-                                                                         "identifier": "FR22_FLIGHT_0",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18032,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 2048,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 11,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                           "FR22_FLIGHT_1": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Flight 1",
-                                                                         "identifier": "FR22_FLIGHT_1",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18032,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 4096,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 12,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                           "FR22_FLIGHT_2": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Flight 2",
-                                                                         "identifier": "FR22_FLIGHT_2",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18032,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 8192,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 13,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                           "FR22_FLIGHT_3": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Flight 3",
-                                                                         "identifier": "FR22_FLIGHT_3",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18032,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 16384,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 14,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                           "FR22_FLIGHT_4": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Flight 4",
-                                                                         "identifier": "FR22_FLIGHT_4",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18032,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 32768,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 15,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                           "FR22_FLIGHT_5": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Flight 5",
-                                                                         "identifier": "FR22_FLIGHT_5",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18064,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 1,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 0,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                           "FR22_FLIGHT_6": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Flight 6",
-                                                                         "identifier": "FR22_FLIGHT_6",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18064,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 2,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 1,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                           "FR22_FLIGHT_7": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Flight 7",
-                                                                         "identifier": "FR22_FLIGHT_7",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18064,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 4,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 2,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                           "FR22_FLIGHT_8": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Flight 8",
-                                                                         "identifier": "FR22_FLIGHT_8",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18064,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 8,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 3,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                           "FR22_FLIGHT_9": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Flight 9",
-                                                                         "identifier": "FR22_FLIGHT_9",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18064,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 16,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 4,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                         "FR22_GROUND_COM": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Ground Intercom",
-                                                                         "identifier": "FR22_GROUND_COM",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18064,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 32768,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 15,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                              "FR22_GROUP": {
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "FR22 Group Selector",
-                                                                         "identifier": "FR22_GROUP",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 10
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18066,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 1920,
-                                                                                             "max_value": 10,
-                                                                                              "shift_by": 7,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "limited_rotary"
-                                                            },
-                                    "FR22_INNER_LEFT_KNOB": {
-                                                                 "api_variant": "multiturn",
-                                                                    "category": "FR22 Radio",
-                                                                "control_type": "analog_dial",
-                                                                 "description": "Radio Frequency Knob Inner Left",
-                                                                  "identifier": "FR22_INNER_LEFT_KNOB",
-                                                                      "inputs": [ {
-                                                                                       "description": "turn the dial left or right",
-                                                                                         "interface": "variable_step",
-                                                                                         "max_value": 65535,
-                                                                                    "suggested_step": 3200
-                                                                                } ],
-                                                                     "outputs": [ {
-                                                                                        "address": 17946,
-                                                                                    "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
-                                                                                           "mask": 65535,
-                                                                                      "max_value": 65535,
-                                                                                       "shift_by": 0,
-                                                                                         "suffix": "_KNOB_POS",
-                                                                                           "type": "integer"
-                                                                                } ]
-                                                            },
-                                   "FR22_INNER_RIGHT_KNOB": {
-                                                                 "api_variant": "multiturn",
-                                                                    "category": "FR22 Radio",
-                                                                "control_type": "analog_dial",
-                                                                 "description": "Radio Frequency Knob Inner Right",
-                                                                  "identifier": "FR22_INNER_RIGHT_KNOB",
-                                                                      "inputs": [ {
-                                                                                       "description": "turn the dial left or right",
-                                                                                         "interface": "variable_step",
-                                                                                         "max_value": 65535,
-                                                                                    "suggested_step": 3200
-                                                                                } ],
-                                                                     "outputs": [ {
-                                                                                        "address": 17950,
-                                                                                    "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
-                                                                                           "mask": 65535,
-                                                                                      "max_value": 65535,
-                                                                                       "shift_by": 0,
-                                                                                         "suffix": "_KNOB_POS",
-                                                                                           "type": "integer"
-                                                                                } ]
-                                                            },
-                                              "FR22_MINUS": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Minus",
-                                                                         "identifier": "FR22_MINUS",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18064,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 512,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 9,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                               "FR22_MODE": {
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "FR22 Mode Selector",
-                                                                         "identifier": "FR22_MODE",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 5
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18066,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 7,
-                                                                                             "max_value": 5,
-                                                                                              "shift_by": 0,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "limited_rotary"
-                                                            },
-                                    "FR22_OUTER_LEFT_KNOB": {
-                                                                 "api_variant": "multiturn",
-                                                                    "category": "FR22 Radio",
-                                                                "control_type": "analog_dial",
-                                                                 "description": "Radio Frequency Knob Outer Left",
-                                                                  "identifier": "FR22_OUTER_LEFT_KNOB",
-                                                                      "inputs": [ {
-                                                                                       "description": "turn the dial left or right",
-                                                                                         "interface": "variable_step",
-                                                                                         "max_value": 65535,
-                                                                                    "suggested_step": 3200
-                                                                                } ],
-                                                                     "outputs": [ {
-                                                                                        "address": 17948,
-                                                                                    "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
-                                                                                           "mask": 65535,
-                                                                                      "max_value": 65535,
-                                                                                       "shift_by": 0,
-                                                                                         "suffix": "_KNOB_POS",
-                                                                                           "type": "integer"
-                                                                                } ]
-                                                            },
-                                   "FR22_OUTER_RIGHT_KNOB": {
-                                                                 "api_variant": "multiturn",
-                                                                    "category": "FR22 Radio",
-                                                                "control_type": "analog_dial",
-                                                                 "description": "Radio Frequency Knob Outer Right",
-                                                                  "identifier": "FR22_OUTER_RIGHT_KNOB",
-                                                                      "inputs": [ {
-                                                                                       "description": "turn the dial left or right",
-                                                                                         "interface": "variable_step",
-                                                                                         "max_value": 65535,
-                                                                                    "suggested_step": 3200
-                                                                                } ],
-                                                                     "outputs": [ {
-                                                                                        "address": 17952,
-                                                                                    "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
-                                                                                           "mask": 65535,
-                                                                                      "max_value": 65535,
-                                                                                       "shift_by": 0,
-                                                                                         "suffix": "_KNOB_POS",
-                                                                                           "type": "integer"
-                                                                                } ]
-                                                            },
-                                     "FR22_SET_MODULATION": {
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "action",
-                                                                        "description": "Radio Manual Frequency Setting Modulation",
-                                                                         "identifier": "FR22_SET_MODULATION",
-                                                                             "inputs": [ {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 17942,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 32768,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 15,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "limited_rotary"
-                                                            },
-                                          "FR22_SPECIAL_1": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Special 1",
-                                                                         "identifier": "FR22_SPECIAL_1",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18064,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 64,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 6,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                          "FR22_SPECIAL_2": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Special 2",
-                                                                         "identifier": "FR22_SPECIAL_2",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18064,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 128,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 7,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                          "FR22_SPECIAL_3": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "FR22 Radio",
-                                                                       "control_type": "selector",
-                                                                        "description": "Special 3",
-                                                                         "identifier": "FR22_SPECIAL_3",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 18064,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 256,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 8,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                                "FR22_VOL": {
-                                                                 "api_variant": "multiturn",
-                                                                    "category": "FR22 Radio",
-                                                                "control_type": "analog_dial",
-                                                                 "description": "Radio Volume",
-                                                                  "identifier": "FR22_VOL",
-                                                                      "inputs": [ {
-                                                                                       "description": "turn the dial left or right",
-                                                                                         "interface": "variable_step",
-                                                                                         "max_value": 65535,
-                                                                                    "suggested_step": 3200
-                                                                                } ],
-                                                                     "outputs": [ {
-                                                                                        "address": 18068,
-                                                                                    "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
-                                                                                           "mask": 65535,
-                                                                                      "max_value": 65535,
-                                                                                       "shift_by": 0,
-                                                                                         "suffix": "_KNOB_POS",
-                                                                                           "type": "integer"
-                                                                                } ]
-                                                            }
-                               },
-           "Flight Data Unit": {
-                                               "AFK_15_DEG_MODE": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "action",
-                                                                              "description": "AFK 15 Deg Mode",
-                                                                               "identifier": "AFK_15_DEG_MODE",
-                                                                                   "inputs": [ {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17940,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 4096,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 12,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "limited_rotary"
-                                                                  },
-                                                    "AFK_MODE_3": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "action",
-                                                                              "description": "AFK Mode 3",
-                                                                               "identifier": "AFK_MODE_3",
-                                                                                   "inputs": [ {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17940,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 2048,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 11,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "limited_rotary"
-                                                                  },
-                                                 "ALTITUDE_HOLD": {
-                                                                              "api_variant": "momentary_last_position",
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Altitude Hold",
-                                                                               "identifier": "ALTITUDE_HOLD",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17936,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 32,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 5,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "push_button"
-                                                                  },
-                                                       "ALT_SET": {
-                                                                          "category": "Flight Data Unit",
-                                                                      "control_type": "limited_dial",
-                                                                       "description": "Altimeter Setting",
-                                                                        "identifier": "ALT_SET",
-                                                                            "inputs": [ {
-                                                                                          "description": "set the position of the dial",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 65535
-                                                                                      }, {
-                                                                                             "description": "turn the dial left or right",
-                                                                                               "interface": "variable_step",
-                                                                                               "max_value": 65535,
-                                                                                          "suggested_step": 3200
-                                                                                      } ],
-                                                                           "outputs": [ {
-                                                                                              "address": 18054,
-                                                                                          "description": "position of the potentiometer",
-                                                                                                 "mask": 65535,
-                                                                                            "max_value": 65535,
-                                                                                             "shift_by": 0,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ]
-                                                                  },
-                                                 "ATTITUDE_HOLD": {
-                                                                              "api_variant": "momentary_last_position",
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Attitude Hold",
-                                                                               "identifier": "ATTITUDE_HOLD",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17936,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 16,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 4,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "push_button"
-                                                                  },
-                                                 "AUTO_YAW_TRIM": {
-                                                                          "category": "Flight Data Unit",
-                                                                      "control_type": "limited_dial",
-                                                                       "description": "Autopilot Yaw Trim",
-                                                                        "identifier": "AUTO_YAW_TRIM",
-                                                                            "inputs": [ {
-                                                                                          "description": "set the position of the dial",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 65535
-                                                                                      }, {
-                                                                                             "description": "turn the dial left or right",
-                                                                                               "interface": "variable_step",
-                                                                                               "max_value": 65535,
-                                                                                          "suggested_step": 3200
-                                                                                      } ],
-                                                                           "outputs": [ {
-                                                                                              "address": 18060,
-                                                                                          "description": "position of the potentiometer",
-                                                                                                 "mask": 65535,
-                                                                                            "max_value": 65535,
-                                                                                             "shift_by": 0,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ]
-                                                                  },
-                                            "BACKUP_ALT_SETTING": {
-                                                                          "category": "Flight Data Unit",
-                                                                      "control_type": "limited_dial",
-                                                                       "description": "Backup Altimeter Setting",
-                                                                        "identifier": "BACKUP_ALT_SETTING",
-                                                                            "inputs": [ {
-                                                                                          "description": "set the position of the dial",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 65535
-                                                                                      }, {
-                                                                                             "description": "turn the dial left or right",
-                                                                                               "interface": "variable_step",
-                                                                                               "max_value": 65535,
-                                                                                          "suggested_step": 3200
-                                                                                      } ],
-                                                                           "outputs": [ {
-                                                                                              "address": 17938,
-                                                                                          "description": "position of the potentiometer",
-                                                                                                 "mask": 65535,
-                                                                                            "max_value": 65535,
-                                                                                             "shift_by": 0,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ]
-                                                                  },
-                                                 "BACK_ADI_CAGE": {
-                                                                              "api_variant": "momentary_last_position",
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Backup ADI Cage",
-                                                                               "identifier": "BACK_ADI_CAGE",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 18032,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 512,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 9,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "push_button"
-                                                                  },
-                                               "CANOPY_JETTISON": {
-                                                                              "api_variant": "momentary_last_position",
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Canopy Jettison",
-                                                                               "identifier": "CANOPY_JETTISON",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17940,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 4,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 2,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "push_button"
-                                                                  },
-                                             "CANOPY_OPEN_CLOSE": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Canopy Open/Close",
-                                                                               "identifier": "CANOPY_OPEN_CLOSE",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 2
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17940,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 3,
-                                                                                                   "max_value": 2,
-                                                                                                    "shift_by": 0,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "limited_rotary"
-                                                                  },
-                                                     "CLOCK_SET": {
-                                                                          "category": "Flight Data Unit",
-                                                                      "control_type": "limited_dial",
-                                                                       "description": "Clock Setting",
-                                                                        "identifier": "CLOCK_SET",
-                                                                            "inputs": [ {
-                                                                                          "description": "set the position of the dial",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 65535
-                                                                                      }, {
-                                                                                             "description": "turn the dial left or right",
-                                                                                               "interface": "variable_step",
-                                                                                               "max_value": 65535,
-                                                                                          "suggested_step": 3200
-                                                                                      } ],
-                                                                           "outputs": [ {
-                                                                                              "address": 18062,
-                                                                                          "description": "position of the potentiometer",
-                                                                                                 "mask": 65535,
-                                                                                            "max_value": 65535,
-                                                                                             "shift_by": 0,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ]
-                                                                  },
-                                   "COUNTERMEASURE_FAST_RELEASE": {
-                                                                              "api_variant": "momentary_last_position",
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Countermeasure Fast Release",
-                                                                               "identifier": "COUNTERMEASURE_FAST_RELEASE",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17940,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 8,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 3,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "push_button"
-                                                                  },
-                                             "EJECTION_SEAT_ARM": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Ejection Seat Arm",
-                                                                               "identifier": "EJECTION_SEAT_ARM",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17936,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 2048,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 11,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "toggle_switch"
-                                                                  },
-                                          "EMERGENCY_PITCH_TRIM": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Emergency Pitch Trim",
-                                                                               "identifier": "EMERGENCY_PITCH_TRIM",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17940,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 32,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 5,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "toggle_switch"
-                                                                  },
-                                           "EMERGENCY_ROLL_TRIM": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Emergency Roll Trim",
-                                                                               "identifier": "EMERGENCY_ROLL_TRIM",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17940,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 16,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 4,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "toggle_switch"
-                                                                  },
-                                            "EMERGENCY_YAW_TRIM": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Emergency Yaw Trim",
-                                                                               "identifier": "EMERGENCY_YAW_TRIM",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17940,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 64,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 6,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "toggle_switch"
-                                                                  },
-                                                   "GEAR_HANDLE": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Gear Handle",
-                                                                               "identifier": "GEAR_HANDLE",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17936,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 4,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 2,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "toggle_switch"
-                                                                  },
-                                                     "HOJD_CISI": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "HOJD CISI",
-                                                                               "identifier": "HOJD_CISI",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17936,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 8192,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 13,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "toggle_switch"
-                                                                  },
-                                                    "HUD_BRIGHT": {
-                                                                          "category": "Flight Data Unit",
-                                                                      "control_type": "limited_dial",
-                                                                       "description": "HUD Brightness Knob",
-                                                                        "identifier": "HUD_BRIGHT",
-                                                                            "inputs": [ {
-                                                                                          "description": "set the position of the dial",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 65535
-                                                                                      }, {
-                                                                                             "description": "turn the dial left or right",
-                                                                                               "interface": "variable_step",
-                                                                                               "max_value": 65535,
-                                                                                          "suggested_step": 3200
-                                                                                      } ],
-                                                                           "outputs": [ {
-                                                                                              "address": 18056,
-                                                                                          "description": "position of the potentiometer",
-                                                                                                 "mask": 65535,
-                                                                                            "max_value": 65535,
-                                                                                             "shift_by": 0,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ]
-                                                                  },
-                                            "HUD_GLASS_POSITION": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "action",
-                                                                              "description": "HUD Reflector Glass Position",
-                                                                               "identifier": "HUD_GLASS_POSITION",
-                                                                                   "inputs": [ {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17940,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 1024,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 10,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "limited_rotary"
-                                                                  },
-                                                "MAG_CORRECTION": {
-                                                                          "category": "Flight Data Unit",
-                                                                      "control_type": "limited_dial",
-                                                                       "description": "Magnetic Declination Correction",
-                                                                        "identifier": "MAG_CORRECTION",
-                                                                            "inputs": [ {
-                                                                                          "description": "set the position of the dial",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 65535
-                                                                                      }, {
-                                                                                             "description": "turn the dial left or right",
-                                                                                               "interface": "variable_step",
-                                                                                               "max_value": 65535,
-                                                                                          "suggested_step": 3200
-                                                                                      } ],
-                                                                           "outputs": [ {
-                                                                                              "address": 18058,
-                                                                                          "description": "position of the potentiometer",
-                                                                                                 "mask": 65535,
-                                                                                            "max_value": 65535,
-                                                                                             "shift_by": 0,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ]
-                                                                  },
-                                                 "MAG_DEC_COVER": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Magnetic Declination Cover",
-                                                                               "identifier": "MAG_DEC_COVER",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17940,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 128,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 7,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "toggle_switch"
-                                                                  },
-                                            "MASTER_MODE_SELECT": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Master Mode Selector",
-                                                                               "identifier": "MASTER_MODE_SELECT",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 6
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17940,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 57344,
-                                                                                                   "max_value": 6,
-                                                                                                    "shift_by": 13,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "limited_rotary"
-                                                                  },
-                                                   "MAX_G_RESET": {
-                                                                              "api_variant": "momentary_last_position",
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Max G Reset",
-                                                                               "identifier": "MAX_G_RESET",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 18032,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 256,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 8,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "push_button"
-                                                                  },
-                                                  "OXYGEN_LEVER": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Oxygen Lever",
-                                                                               "identifier": "OXYGEN_LEVER",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17936,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 32768,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 15,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "toggle_switch"
-                                                                  },
-                                                 "PARKING_BRAKE": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "action",
-                                                                              "description": "Parking Brake",
-                                                                               "identifier": "PARKING_BRAKE",
-                                                                                   "inputs": [ {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17940,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 512,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 9,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "limited_rotary"
-                                                                  },
-                                               "PITCH_GEAR_MODE": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Pitch Gear Automatic/Landing",
-                                                                               "identifier": "PITCH_GEAR_MODE",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17936,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 16384,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 14,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "toggle_switch"
-                                                                  },
-                                                   "ROLL_CENTER": {
-                                                                              "api_variant": "momentary_last_position",
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Roll Centering",
-                                                                               "identifier": "ROLL_CENTER",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 18032,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 1024,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 10,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "push_button"
-                                                                  },
-                                                       "SLAV_SI": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Slav SI",
-                                                                               "identifier": "SLAV_SI",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17936,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 4096,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 12,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "toggle_switch"
-                                                                  },
-                                                          "SPAK": {
-                                                                              "api_variant": "momentary_last_position",
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "SPAK",
-                                                                               "identifier": "SPAK",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17936,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 8,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 3,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "push_button"
-                                                                  },
-                                            "TILS_CHANNEL_LAYER": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "TILS Channel Layer Selection",
-                                                                               "identifier": "TILS_CHANNEL_LAYER",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17936,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 1024,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 10,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "toggle_switch"
-                                                                  },
-                                           "TILS_CHANNEL_SELECT": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "TILS Channel Selection",
-                                                                               "identifier": "TILS_CHANNEL_SELECT",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 10
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17936,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 960,
-                                                                                                   "max_value": 10,
-                                                                                                    "shift_by": 6,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "limited_rotary"
-                                                                  },
-                                                "YAW_TRIM_COVER": {
-                                                                                 "category": "Flight Data Unit",
-                                                                             "control_type": "selector",
-                                                                              "description": "Autopilot Yaw Trim Cover",
-                                                                               "identifier": "YAW_TRIM_COVER",
-                                                                                   "inputs": [ {
-                                                                                                 "description": "switch to previous or next state",
-                                                                                                   "interface": "fixed_step"
-                                                                                             }, {
-                                                                                                 "description": "set position",
-                                                                                                   "interface": "set_state",
-                                                                                                   "max_value": 1
-                                                                                             }, {
-                                                                                                    "argument": "TOGGLE",
-                                                                                                 "description": "Toggle switch state",
-                                                                                                   "interface": "action"
-                                                                                             } ],
-                                                                      "momentary_positions": "none",
-                                                                                  "outputs": [ {
-                                                                                                     "address": 17940,
-                                                                                                 "description": "selector position",
-                                                                                                        "mask": 256,
-                                                                                                   "max_value": 1,
-                                                                                                    "shift_by": 8,
-                                                                                                      "suffix": "",
-                                                                                                        "type": "integer"
-                                                                                             } ],
-                                                                         "physical_variant": "toggle_switch"
-                                                                  }
-                               },
-               "Gauge Values": {
-                                             "AIRSPEED_VALUE": {
-                                                                       "category": "Gauge Values",
-                                                                   "control_type": "metadata",
-                                                                    "description": "Airspeed Value",
-                                                                     "identifier": "AIRSPEED_VALUE",
-                                                                         "inputs": [  ],
-                                                                        "outputs": [ {
-                                                                                           "address": 18038,
-                                                                                       "description": "Airspeed Value",
-                                                                                              "mask": 65535,
-                                                                                         "max_value": 65000,
-                                                                                          "shift_by": 0,
-                                                                                            "suffix": "",
-                                                                                              "type": "integer"
-                                                                                   } ]
-                                                               },
-                                             "ALTITUDE_VALUE": {
-                                                                       "category": "Gauge Values",
-                                                                   "control_type": "metadata",
-                                                                    "description": "Altitude Value",
-                                                                     "identifier": "ALTITUDE_VALUE",
-                                                                         "inputs": [  ],
-                                                                        "outputs": [ {
-                                                                                           "address": 18040,
-                                                                                       "description": "Altitude Value",
-                                                                                              "mask": 65535,
-                                                                                         "max_value": 65000,
-                                                                                          "shift_by": 0,
-                                                                                            "suffix": "",
-                                                                                              "type": "integer"
-                                                                                   } ]
-                                                               },
-                                   "CI_COMMAND_HEADING_VALUE": {
-                                                                       "category": "Gauge Values",
-                                                                   "control_type": "metadata",
-                                                                    "description": "CI Commanded Heading Value",
-                                                                     "identifier": "CI_COMMAND_HEADING_VALUE",
-                                                                         "inputs": [  ],
-                                                                        "outputs": [ {
-                                                                                           "address": 18048,
-                                                                                       "description": "CI Commanded Heading Value",
-                                                                                              "mask": 65535,
-                                                                                         "max_value": 65000,
-                                                                                          "shift_by": 0,
-                                                                                            "suffix": "",
-                                                                                              "type": "integer"
-                                                                                   } ]
-                                                               },
-                                           "CI_HEADING_VALUE": {
-                                                                       "category": "Gauge Values",
-                                                                   "control_type": "metadata",
-                                                                    "description": "CI Heading Value",
-                                                                     "identifier": "CI_HEADING_VALUE",
-                                                                         "inputs": [  ],
-                                                                        "outputs": [ {
-                                                                                           "address": 18046,
-                                                                                       "description": "CI Heading Value",
-                                                                                              "mask": 65535,
-                                                                                         "max_value": 65000,
-                                                                                          "shift_by": 0,
-                                                                                            "suffix": "",
-                                                                                              "type": "integer"
-                                                                                   } ]
-                                                               },
-                                           "ENGINE_RPM_VALUE": {
-                                                                       "category": "Gauge Values",
-                                                                   "control_type": "metadata",
-                                                                    "description": "Engine RPM Value",
-                                                                     "identifier": "ENGINE_RPM_VALUE",
-                                                                         "inputs": [  ],
-                                                                        "outputs": [ {
-                                                                                           "address": 18034,
-                                                                                       "description": "Engine RPM Value",
-                                                                                              "mask": 65535,
-                                                                                         "max_value": 65000,
-                                                                                          "shift_by": 0,
-                                                                                            "suffix": "",
-                                                                                              "type": "integer"
-                                                                                   } ]
-                                                               },
-                                          "ENGINE_TEMP_VALUE": {
-                                                                       "category": "Gauge Values",
-                                                                   "control_type": "metadata",
-                                                                    "description": "Engine Temp Value",
-                                                                     "identifier": "ENGINE_TEMP_VALUE",
-                                                                         "inputs": [  ],
-                                                                        "outputs": [ {
-                                                                                           "address": 18036,
-                                                                                       "description": "Engine Temp Value",
-                                                                                              "mask": 65535,
-                                                                                         "max_value": 65000,
-                                                                                          "shift_by": 0,
-                                                                                            "suffix": "",
-                                                                                              "type": "integer"
-                                                                                   } ]
-                                                               },
-                                           "FUEL_LEVEL_VALUE": {
-                                                                       "category": "Gauge Values",
-                                                                   "control_type": "metadata",
-                                                                    "description": "Fuel Level Value",
-                                                                     "identifier": "FUEL_LEVEL_VALUE",
-                                                                         "inputs": [  ],
-                                                                        "outputs": [ {
-                                                                                           "address": 18042,
-                                                                                       "description": "Fuel Level Value",
-                                                                                              "mask": 65535,
-                                                                                         "max_value": 65000,
-                                                                                          "shift_by": 0,
-                                                                                            "suffix": "",
-                                                                                              "type": "integer"
-                                                                                   } ]
-                                                               },
-                                          "FUEL_NEEDED_VALUE": {
-                                                                       "category": "Gauge Values",
-                                                                   "control_type": "metadata",
-                                                                    "description": "Fuel Needed Value",
-                                                                     "identifier": "FUEL_NEEDED_VALUE",
-                                                                         "inputs": [  ],
-                                                                        "outputs": [ {
-                                                                                           "address": 18044,
-                                                                                       "description": "Fuel Needed Value",
-                                                                                              "mask": 65535,
-                                                                                         "max_value": 65000,
-                                                                                          "shift_by": 0,
-                                                                                            "suffix": "",
-                                                                                              "type": "integer"
-                                                                                   } ]
-                                                               }
-                               },
-           "Indicator Lights": {
-                                    "ATT_LAMP": {
-                                                        "category": "Indicator Lights",
-                                                    "control_type": "led",
-                                                     "description": "ATT Lamp",
-                                                      "identifier": "ATT_LAMP",
-                                                          "inputs": [  ],
-                                                         "outputs": [ {
-                                                                            "address": 17944,
-                                                                        "description": "0 if light is off, 1 if light is on",
-                                                                               "mask": 2048,
-                                                                          "max_value": 1,
-                                                                           "shift_by": 11,
-                                                                             "suffix": "",
-                                                                               "type": "integer"
-                                                                    } ]
-                                                },
-                                   "HOJD_LAMP": {
-                                                        "category": "Indicator Lights",
-                                                    "control_type": "led",
-                                                     "description": "HOJD Lamp",
-                                                      "identifier": "HOJD_LAMP",
-                                                          "inputs": [  ],
-                                                         "outputs": [ {
-                                                                            "address": 17944,
-                                                                        "description": "0 if light is off, 1 if light is on",
-                                                                               "mask": 4096,
-                                                                          "max_value": 1,
-                                                                           "shift_by": 12,
-                                                                             "suffix": "",
-                                                                               "type": "integer"
-                                                                    } ]
-                                                },
-                                   "SPAK_LAMP": {
-                                                        "category": "Indicator Lights",
-                                                    "control_type": "led",
-                                                     "description": "SPAK Lamp",
-                                                      "identifier": "SPAK_LAMP",
-                                                          "inputs": [  ],
-                                                         "outputs": [ {
-                                                                            "address": 17944,
-                                                                        "description": "0 if light is off, 1 if light is on",
-                                                                               "mask": 1024,
-                                                                          "max_value": 1,
-                                                                           "shift_by": 10,
-                                                                             "suffix": "",
-                                                                               "type": "integer"
-                                                                    } ]
-                                                }
-                               },
-                     "Lights": {
-                                        "ANTI_COLLISION_LIGHTS": {
-                                                                                "category": "Lights",
-                                                                            "control_type": "selector",
-                                                                             "description": "Anti Collision Lights",
-                                                                              "identifier": "ANTI_COLLISION_LIGHTS",
-                                                                                  "inputs": [ {
-                                                                                                "description": "switch to previous or next state",
-                                                                                                  "interface": "fixed_step"
-                                                                                            }, {
-                                                                                                "description": "set position",
-                                                                                                  "interface": "set_state",
-                                                                                                  "max_value": 1
-                                                                                            }, {
-                                                                                                   "argument": "TOGGLE",
-                                                                                                "description": "Toggle switch state",
-                                                                                                  "interface": "action"
-                                                                                            } ],
-                                                                     "momentary_positions": "none",
-                                                                                 "outputs": [ {
-                                                                                                    "address": 17924,
-                                                                                                "description": "selector position",
-                                                                                                       "mask": 16384,
-                                                                                                  "max_value": 1,
-                                                                                                   "shift_by": 14,
-                                                                                                     "suffix": "",
-                                                                                                       "type": "integer"
-                                                                                            } ],
-                                                                        "physical_variant": "toggle_switch"
-                                                                 },
-                                             "EMERGENCY_LIGHTS": {
-                                                                                "category": "Lights",
-                                                                            "control_type": "selector",
-                                                                             "description": "Emergency Lights",
-                                                                              "identifier": "EMERGENCY_LIGHTS",
-                                                                                  "inputs": [ {
-                                                                                                "description": "switch to previous or next state",
-                                                                                                  "interface": "fixed_step"
-                                                                                            }, {
-                                                                                                "description": "set position",
-                                                                                                  "interface": "set_state",
-                                                                                                  "max_value": 1
-                                                                                            }, {
-                                                                                                   "argument": "TOGGLE",
-                                                                                                "description": "Toggle switch state",
-                                                                                                  "interface": "action"
-                                                                                            } ],
-                                                                     "momentary_positions": "none",
-                                                                                 "outputs": [ {
-                                                                                                    "address": 17926,
-                                                                                                "description": "selector position",
-                                                                                                       "mask": 16,
-                                                                                                  "max_value": 1,
-                                                                                                   "shift_by": 4,
-                                                                                                     "suffix": "",
-                                                                                                       "type": "integer"
-                                                                                            } ],
-                                                                        "physical_variant": "toggle_switch"
-                                                                 },
-                                                 "FLOOD_LIGHTS": {
-                                                                         "category": "Lights",
-                                                                     "control_type": "limited_dial",
-                                                                      "description": "Flood Lights",
-                                                                       "identifier": "FLOOD_LIGHTS",
-                                                                           "inputs": [ {
-                                                                                         "description": "set the position of the dial",
-                                                                                           "interface": "set_state",
-                                                                                           "max_value": 65535
-                                                                                     }, {
-                                                                                            "description": "turn the dial left or right",
-                                                                                              "interface": "variable_step",
-                                                                                              "max_value": 65535,
-                                                                                         "suggested_step": 3200
-                                                                                     } ],
-                                                                          "outputs": [ {
-                                                                                             "address": 17928,
-                                                                                         "description": "position of the potentiometer",
-                                                                                                "mask": 65535,
-                                                                                           "max_value": 65535,
-                                                                                            "shift_by": 0,
-                                                                                              "suffix": "",
-                                                                                                "type": "integer"
-                                                                                     } ]
-                                                                 },
-                                             "FORMATION_LIGHTS": {
-                                                                                "category": "Lights",
-                                                                            "control_type": "selector",
-                                                                             "description": "Formation Lights",
-                                                                              "identifier": "FORMATION_LIGHTS",
-                                                                                  "inputs": [ {
-                                                                                                "description": "switch to previous or next state",
-                                                                                                  "interface": "fixed_step"
-                                                                                            }, {
-                                                                                                "description": "set position",
-                                                                                                  "interface": "set_state",
-                                                                                                  "max_value": 1
-                                                                                            }, {
-                                                                                                   "argument": "TOGGLE",
-                                                                                                "description": "Toggle switch state",
-                                                                                                  "interface": "action"
-                                                                                            } ],
-                                                                     "momentary_positions": "none",
-                                                                                 "outputs": [ {
-                                                                                                    "address": 17924,
-                                                                                                "description": "selector position",
-                                                                                                       "mask": 32768,
-                                                                                                  "max_value": 1,
-                                                                                                   "shift_by": 15,
-                                                                                                     "suffix": "",
-                                                                                                       "type": "integer"
-                                                                                            } ],
-                                                                        "physical_variant": "toggle_switch"
-                                                                 },
-                                            "INSTRUMENT_LIGHTS": {
-                                                                         "category": "Lights",
-                                                                     "control_type": "limited_dial",
-                                                                      "description": "Instrument Lights",
-                                                                       "identifier": "INSTRUMENT_LIGHTS",
-                                                                           "inputs": [ {
-                                                                                         "description": "set the position of the dial",
-                                                                                           "interface": "set_state",
-                                                                                           "max_value": 65535
-                                                                                     }, {
-                                                                                            "description": "turn the dial left or right",
-                                                                                              "interface": "variable_step",
-                                                                                              "max_value": 65535,
-                                                                                         "suggested_step": 3200
-                                                                                     } ],
-                                                                          "outputs": [ {
-                                                                                             "address": 17932,
-                                                                                         "description": "position of the potentiometer",
-                                                                                                "mask": 65535,
-                                                                                           "max_value": 65535,
-                                                                                            "shift_by": 0,
-                                                                                              "suffix": "",
-                                                                                                "type": "integer"
-                                                                                     } ]
-                                                                 },
-                                            "NAVIGATION_LIGHTS": {
-                                                                                "category": "Lights",
-                                                                            "control_type": "selector",
-                                                                             "description": "Navigation Lights",
-                                                                              "identifier": "NAVIGATION_LIGHTS",
-                                                                                  "inputs": [ {
-                                                                                                "description": "switch to previous or next state",
-                                                                                                  "interface": "fixed_step"
-                                                                                            }, {
-                                                                                                "description": "set position",
-                                                                                                  "interface": "set_state",
-                                                                                                  "max_value": 2
-                                                                                            } ],
-                                                                     "momentary_positions": "none",
-                                                                                 "outputs": [ {
-                                                                                                    "address": 17926,
-                                                                                                "description": "selector position",
-                                                                                                       "mask": 3,
-                                                                                                  "max_value": 2,
-                                                                                                   "shift_by": 0,
-                                                                                                     "suffix": "",
-                                                                                                       "type": "integer"
-                                                                                            } ],
-                                                                        "physical_variant": "limited_rotary"
-                                                                 },
-                                                 "PANEL_LIGHTS": {
-                                                                         "category": "Lights",
-                                                                     "control_type": "limited_dial",
-                                                                      "description": "Panel Lights",
-                                                                       "identifier": "PANEL_LIGHTS",
-                                                                           "inputs": [ {
-                                                                                         "description": "set the position of the dial",
-                                                                                           "interface": "set_state",
-                                                                                           "max_value": 65535
-                                                                                     }, {
-                                                                                            "description": "turn the dial left or right",
-                                                                                              "interface": "variable_step",
-                                                                                              "max_value": 65535,
-                                                                                         "suggested_step": 3200
-                                                                                     } ],
-                                                                          "outputs": [ {
-                                                                                             "address": 17930,
-                                                                                         "description": "position of the potentiometer",
-                                                                                                "mask": 65535,
-                                                                                           "max_value": 65535,
-                                                                                            "shift_by": 0,
-                                                                                              "suffix": "",
-                                                                                                "type": "integer"
-                                                                                     } ]
-                                                                 },
-                                              "POSITION_LIGHTS": {
-                                                                                "category": "Lights",
-                                                                            "control_type": "selector",
-                                                                             "description": "Position Lights",
-                                                                              "identifier": "POSITION_LIGHTS",
-                                                                                  "inputs": [ {
-                                                                                                "description": "switch to previous or next state",
-                                                                                                  "interface": "fixed_step"
-                                                                                            }, {
-                                                                                                "description": "set position",
-                                                                                                  "interface": "set_state",
-                                                                                                  "max_value": 1
-                                                                                            }, {
-                                                                                                   "argument": "TOGGLE",
-                                                                                                "description": "Toggle switch state",
-                                                                                                  "interface": "action"
-                                                                                            } ],
-                                                                     "momentary_positions": "none",
-                                                                                 "outputs": [ {
-                                                                                                    "address": 17926,
-                                                                                                "description": "selector position",
-                                                                                                       "mask": 4,
-                                                                                                  "max_value": 1,
-                                                                                                   "shift_by": 2,
-                                                                                                     "suffix": "",
-                                                                                                       "type": "integer"
-                                                                                            } ],
-                                                                        "physical_variant": "toggle_switch"
-                                                                 },
-                                   "POSITION_LIGHTS_BRIGHTNESS": {
-                                                                                "category": "Lights",
-                                                                            "control_type": "selector",
-                                                                             "description": "Position Lights Brightness",
-                                                                              "identifier": "POSITION_LIGHTS_BRIGHTNESS",
-                                                                                  "inputs": [ {
-                                                                                                "description": "switch to previous or next state",
-                                                                                                  "interface": "fixed_step"
-                                                                                            }, {
-                                                                                                "description": "set position",
-                                                                                                  "interface": "set_state",
-                                                                                                  "max_value": 2
-                                                                                            } ],
-                                                                     "momentary_positions": "none",
-                                                                                 "outputs": [ {
-                                                                                                    "address": 17926,
-                                                                                                "description": "selector position",
-                                                                                                       "mask": 96,
-                                                                                                  "max_value": 2,
-                                                                                                   "shift_by": 5,
-                                                                                                     "suffix": "",
-                                                                                                       "type": "integer"
-                                                                                            } ],
-                                                                        "physical_variant": "limited_rotary"
-                                                                 },
-                                          "TAXI_LANDING_LIGHTS": {
-                                                                                "category": "Lights",
-                                                                            "control_type": "selector",
-                                                                             "description": "Taxi/Landing Lights",
-                                                                              "identifier": "TAXI_LANDING_LIGHTS",
-                                                                                  "inputs": [ {
-                                                                                                "description": "switch to previous or next state",
-                                                                                                  "interface": "fixed_step"
-                                                                                            }, {
-                                                                                                "description": "set position",
-                                                                                                  "interface": "set_state",
-                                                                                                  "max_value": 1
-                                                                                            }, {
-                                                                                                   "argument": "TOGGLE",
-                                                                                                "description": "Toggle switch state",
-                                                                                                  "interface": "action"
-                                                                                            } ],
-                                                                     "momentary_positions": "none",
-                                                                                 "outputs": [ {
-                                                                                                    "address": 17926,
-                                                                                                "description": "selector position",
-                                                                                                       "mask": 8,
-                                                                                                  "max_value": 1,
-                                                                                                   "shift_by": 3,
-                                                                                                     "suffix": "",
-                                                                                                       "type": "integer"
-                                                                                            } ],
-                                                                        "physical_variant": "toggle_switch"
-                                                                 }
-                               },
-                 "Navigation": {
-                                        "DATAPANEL_KEY_0": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Datapanel Key 0",
-                                                                        "identifier": "DATAPANEL_KEY_0",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17922,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 256,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 8,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                        "DATAPANEL_KEY_1": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Datapanel Key 1",
-                                                                        "identifier": "DATAPANEL_KEY_1",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17922,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 512,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 9,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                        "DATAPANEL_KEY_2": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Datapanel Key 2",
-                                                                        "identifier": "DATAPANEL_KEY_2",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17922,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 1024,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 10,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                        "DATAPANEL_KEY_3": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Datapanel Key 3",
-                                                                        "identifier": "DATAPANEL_KEY_3",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17922,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 2048,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 11,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                        "DATAPANEL_KEY_4": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Datapanel Key 4",
-                                                                        "identifier": "DATAPANEL_KEY_4",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17922,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 4096,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 12,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                        "DATAPANEL_KEY_5": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Datapanel Key 5",
-                                                                        "identifier": "DATAPANEL_KEY_5",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17922,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 8192,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 13,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                        "DATAPANEL_KEY_6": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Datapanel Key 6",
-                                                                        "identifier": "DATAPANEL_KEY_6",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17922,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 16384,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 14,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                        "DATAPANEL_KEY_7": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Datapanel Key 7",
-                                                                        "identifier": "DATAPANEL_KEY_7",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17922,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 32768,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 15,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                        "DATAPANEL_KEY_8": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Datapanel Key 8",
-                                                                        "identifier": "DATAPANEL_KEY_8",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17924,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 1,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 0,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                        "DATAPANEL_KEY_9": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Datapanel Key 9",
-                                                                        "identifier": "DATAPANEL_KEY_9",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17924,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 2,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 1,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                      "NAV_SELECT_BTN_B1": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Navigation Selector Button B1",
-                                                                        "identifier": "NAV_SELECT_BTN_B1",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17924,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 4,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 2,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                      "NAV_SELECT_BTN_B2": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Navigation Selector Button B2",
-                                                                        "identifier": "NAV_SELECT_BTN_B2",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17924,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 8,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 3,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                      "NAV_SELECT_BTN_B3": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Navigation Selector Button B3",
-                                                                        "identifier": "NAV_SELECT_BTN_B3",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17924,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 16,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 4,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                      "NAV_SELECT_BTN_B4": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Navigation Selector Button B4",
-                                                                        "identifier": "NAV_SELECT_BTN_B4",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17924,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 32,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 5,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                      "NAV_SELECT_BTN_B5": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Navigation Selector Button B5",
-                                                                        "identifier": "NAV_SELECT_BTN_B5",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17924,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 64,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 6,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                      "NAV_SELECT_BTN_B6": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Navigation Selector Button B6",
-                                                                        "identifier": "NAV_SELECT_BTN_B6",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17924,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 128,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 7,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                      "NAV_SELECT_BTN_B7": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Navigation Selector Button B7",
-                                                                        "identifier": "NAV_SELECT_BTN_B7",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17924,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 256,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 8,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                      "NAV_SELECT_BTN_B8": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Navigation Selector Button B8",
-                                                                        "identifier": "NAV_SELECT_BTN_B8",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17924,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 512,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 9,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                      "NAV_SELECT_BTN_B9": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Navigation Selector Button B9",
-                                                                        "identifier": "NAV_SELECT_BTN_B9",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17924,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 1024,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 10,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                      "NAV_SELECT_BTN_BX": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Navigation Selector Button BX",
-                                                                        "identifier": "NAV_SELECT_BTN_BX",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17924,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 2048,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 11,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                      "NAV_SELECT_BTN_LS": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Navigation Selector Button LS",
-                                                                        "identifier": "NAV_SELECT_BTN_LS",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17924,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 4096,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 12,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           },
-                                   "NAV_SELECT_BTN_L_MAL": {
-                                                                       "api_variant": "momentary_last_position",
-                                                                          "category": "Navigation",
-                                                                      "control_type": "selector",
-                                                                       "description": "Navigation Selector Button L MAL",
-                                                                        "identifier": "NAV_SELECT_BTN_L_MAL",
-                                                                            "inputs": [ {
-                                                                                          "description": "switch to previous or next state",
-                                                                                            "interface": "fixed_step"
-                                                                                      }, {
-                                                                                          "description": "set position",
-                                                                                            "interface": "set_state",
-                                                                                            "max_value": 1
-                                                                                      }, {
-                                                                                             "argument": "TOGGLE",
-                                                                                          "description": "Toggle switch state",
-                                                                                            "interface": "action"
-                                                                                      } ],
-                                                               "momentary_positions": "none",
-                                                                           "outputs": [ {
-                                                                                              "address": 17924,
-                                                                                          "description": "selector position",
-                                                                                                 "mask": 8192,
-                                                                                            "max_value": 1,
-                                                                                             "shift_by": 13,
-                                                                                               "suffix": "",
-                                                                                                 "type": "integer"
-                                                                                      } ],
-                                                                  "physical_variant": "push_button"
-                                                           }
-                               },
-           "Navigation Panel": {
-                                   "AJS37_NAV_INDICATOR_DATA_1": {
-                                                                         "category": "Navigation Panel",
-                                                                     "control_type": "display",
-                                                                      "description": "Navigataion Panel Data Digit 1",
-                                                                       "identifier": "AJS37_NAV_INDICATOR_DATA_1",
-                                                                           "inputs": [  ],
-                                                                          "outputs": [ {
-                                                                                             "address": 18082,
-                                                                                         "description": "Navigataion Panel Data Digit 1",
-                                                                                          "max_length": 1,
-                                                                                              "suffix": "",
-                                                                                                "type": "string"
-                                                                                     } ]
-                                                                 },
-                                   "AJS37_NAV_INDICATOR_DATA_2": {
-                                                                         "category": "Navigation Panel",
-                                                                     "control_type": "display",
-                                                                      "description": "Navigataion Panel Data Digit 2",
-                                                                       "identifier": "AJS37_NAV_INDICATOR_DATA_2",
-                                                                           "inputs": [  ],
-                                                                          "outputs": [ {
-                                                                                             "address": 18084,
-                                                                                         "description": "Navigataion Panel Data Digit 2",
-                                                                                          "max_length": 1,
-                                                                                              "suffix": "",
-                                                                                                "type": "string"
-                                                                                     } ]
-                                                                 },
-                                   "AJS37_NAV_INDICATOR_DATA_3": {
-                                                                         "category": "Navigation Panel",
-                                                                     "control_type": "display",
-                                                                      "description": "Navigataion Panel Data Digit 3",
-                                                                       "identifier": "AJS37_NAV_INDICATOR_DATA_3",
-                                                                           "inputs": [  ],
-                                                                          "outputs": [ {
-                                                                                             "address": 18086,
-                                                                                         "description": "Navigataion Panel Data Digit 3",
-                                                                                          "max_length": 1,
-                                                                                              "suffix": "",
-                                                                                                "type": "string"
-                                                                                     } ]
-                                                                 },
-                                   "AJS37_NAV_INDICATOR_DATA_4": {
-                                                                         "category": "Navigation Panel",
-                                                                     "control_type": "display",
-                                                                      "description": "Navigataion Panel Data Digit 4",
-                                                                       "identifier": "AJS37_NAV_INDICATOR_DATA_4",
-                                                                           "inputs": [  ],
-                                                                          "outputs": [ {
-                                                                                             "address": 18088,
-                                                                                         "description": "Navigataion Panel Data Digit 4",
-                                                                                          "max_length": 1,
-                                                                                              "suffix": "",
-                                                                                                "type": "string"
-                                                                                     } ]
-                                                                 },
-                                   "AJS37_NAV_INDICATOR_DATA_5": {
-                                                                         "category": "Navigation Panel",
-                                                                     "control_type": "display",
-                                                                      "description": "Navigataion Panel Data Digit 5",
-                                                                       "identifier": "AJS37_NAV_INDICATOR_DATA_5",
-                                                                           "inputs": [  ],
-                                                                          "outputs": [ {
-                                                                                             "address": 18090,
-                                                                                         "description": "Navigataion Panel Data Digit 5",
-                                                                                          "max_length": 1,
-                                                                                              "suffix": "",
-                                                                                                "type": "string"
-                                                                                     } ]
-                                                                 },
-                                   "AJS37_NAV_INDICATOR_DATA_6": {
-                                                                         "category": "Navigation Panel",
-                                                                     "control_type": "display",
-                                                                      "description": "Navigataion Panel Data Digit 6",
-                                                                       "identifier": "AJS37_NAV_INDICATOR_DATA_6",
-                                                                           "inputs": [  ],
-                                                                          "outputs": [ {
-                                                                                             "address": 18092,
-                                                                                         "description": "Navigataion Panel Data Digit 6",
-                                                                                          "max_length": 1,
-                                                                                              "suffix": "",
-                                                                                                "type": "string"
-                                                                                     } ]
-                                                                 },
-                                             "CK37_RENSA_CLEAR": {
-                                                                             "api_variant": "momentary_last_position",
-                                                                                "category": "Navigation Panel",
-                                                                            "control_type": "selector",
-                                                                             "description": "CK37 Rensa Clear",
-                                                                              "identifier": "CK37_RENSA_CLEAR",
-                                                                                  "inputs": [ {
-                                                                                                "description": "switch to previous or next state",
-                                                                                                  "interface": "fixed_step"
-                                                                                            }, {
-                                                                                                "description": "set position",
-                                                                                                  "interface": "set_state",
-                                                                                                  "max_value": 1
-                                                                                            }, {
-                                                                                                   "argument": "TOGGLE",
-                                                                                                "description": "Toggle switch state",
-                                                                                                  "interface": "action"
-                                                                                            } ],
-                                                                     "momentary_positions": "none",
-                                                                                 "outputs": [ {
-                                                                                                    "address": 17942,
-                                                                                                "description": "selector position",
-                                                                                                       "mask": 32,
-                                                                                                  "max_value": 1,
-                                                                                                   "shift_by": 5,
-                                                                                                     "suffix": "",
-                                                                                                       "type": "integer"
-                                                                                            } ],
-                                                                        "physical_variant": "push_button"
-                                                                 },
-                                           "DATAPANEL_SELECTOR": {
-                                                                                "category": "Navigation Panel",
-                                                                            "control_type": "selector",
-                                                                             "description": "Datapanel Selector",
-                                                                              "identifier": "DATAPANEL_SELECTOR",
-                                                                                  "inputs": [ {
-                                                                                                "description": "switch to previous or next state",
-                                                                                                  "interface": "fixed_step"
-                                                                                            }, {
-                                                                                                "description": "set position",
-                                                                                                  "interface": "set_state",
-                                                                                                  "max_value": 6
-                                                                                            } ],
-                                                                     "momentary_positions": "none",
-                                                                                 "outputs": [ {
-                                                                                                    "address": 17942,
-                                                                                                "description": "selector position",
-                                                                                                       "mask": 7,
-                                                                                                  "max_value": 6,
-                                                                                                   "shift_by": 0,
-                                                                                                     "suffix": "",
-                                                                                                       "type": "integer"
-                                                                                            } ],
-                                                                        "physical_variant": "limited_rotary"
-                                                                 },
-                                                  "DATA_IN_OUT": {
-                                                                                "category": "Navigation Panel",
-                                                                            "control_type": "selector",
-                                                                             "description": "Data In/Out",
-                                                                              "identifier": "DATA_IN_OUT",
-                                                                                  "inputs": [ {
-                                                                                                "description": "switch to previous or next state",
-                                                                                                  "interface": "fixed_step"
-                                                                                            }, {
-                                                                                                "description": "set position",
-                                                                                                  "interface": "set_state",
-                                                                                                  "max_value": 1
-                                                                                            }, {
-                                                                                                   "argument": "TOGGLE",
-                                                                                                "description": "Toggle switch state",
-                                                                                                  "interface": "action"
-                                                                                            } ],
-                                                                     "momentary_positions": "none",
-                                                                                 "outputs": [ {
-                                                                                                    "address": 17942,
-                                                                                                "description": "selector position",
-                                                                                                       "mask": 8,
-                                                                                                  "max_value": 1,
-                                                                                                   "shift_by": 3,
-                                                                                                     "suffix": "",
-                                                                                                       "type": "integer"
-                                                                                            } ],
-                                                                        "physical_variant": "toggle_switch"
-                                                                 },
-                                           "RENSA_BUTTON_COVER": {
-                                                                                "category": "Navigation Panel",
-                                                                            "control_type": "selector",
-                                                                             "description": "Rensa Button Cover",
-                                                                              "identifier": "RENSA_BUTTON_COVER",
-                                                                                  "inputs": [ {
-                                                                                                "description": "switch to previous or next state",
-                                                                                                  "interface": "fixed_step"
-                                                                                            }, {
-                                                                                                "description": "set position",
-                                                                                                  "interface": "set_state",
-                                                                                                  "max_value": 1
-                                                                                            }, {
-                                                                                                   "argument": "TOGGLE",
-                                                                                                "description": "Toggle switch state",
-                                                                                                  "interface": "action"
-                                                                                            } ],
-                                                                     "momentary_positions": "none",
-                                                                                 "outputs": [ {
-                                                                                                    "address": 17942,
-                                                                                                "description": "selector position",
-                                                                                                       "mask": 16,
-                                                                                                  "max_value": 1,
-                                                                                                   "shift_by": 4,
-                                                                                                     "suffix": "",
-                                                                                                       "type": "integer"
-                                                                                            } ],
-                                                                        "physical_variant": "toggle_switch"
-                                                                 }
-                               },
-                        "RWR": {
-                                          "MASTER_VOL": {
-                                                                "category": "RWR",
-                                                            "control_type": "limited_dial",
-                                                             "description": "Master Volume / Sidewinder Tone",
-                                                              "identifier": "MASTER_VOL",
-                                                                  "inputs": [ {
-                                                                                "description": "set the position of the dial",
-                                                                                  "interface": "set_state",
-                                                                                  "max_value": 65535
-                                                                            }, {
-                                                                                   "description": "turn the dial left or right",
-                                                                                     "interface": "variable_step",
-                                                                                     "max_value": 65535,
-                                                                                "suggested_step": 3200
-                                                                            } ],
-                                                                 "outputs": [ {
-                                                                                    "address": 18078,
-                                                                                "description": "position of the potentiometer",
-                                                                                       "mask": 65535,
-                                                                                  "max_value": 65535,
-                                                                                   "shift_by": 0,
-                                                                                     "suffix": "",
-                                                                                       "type": "integer"
-                                                                            } ]
-                                                        },
-                                   "RADAR_WARN_SELECT": {
-                                                                       "category": "RWR",
-                                                                   "control_type": "selector",
-                                                                    "description": "Radar Warning Indication Selector",
-                                                                     "identifier": "RADAR_WARN_SELECT",
-                                                                         "inputs": [ {
-                                                                                       "description": "switch to previous or next state",
-                                                                                         "interface": "fixed_step"
-                                                                                   }, {
-                                                                                       "description": "set position",
-                                                                                         "interface": "set_state",
-                                                                                         "max_value": 2
-                                                                                   } ],
-                                                            "momentary_positions": "none",
-                                                                        "outputs": [ {
-                                                                                           "address": 17942,
-                                                                                       "description": "selector position",
-                                                                                              "mask": 192,
-                                                                                         "max_value": 2,
-                                                                                          "shift_by": 6,
-                                                                                            "suffix": "",
-                                                                                              "type": "integer"
-                                                                                   } ],
-                                                               "physical_variant": "limited_rotary"
-                                                        }
-                               },
-                      "Radar": {
-                                              "ANTI_JAM_MODE": {
-                                                                              "category": "Radar",
-                                                                          "control_type": "selector",
-                                                                           "description": "Anti Jamming Mode (AS) Selector",
-                                                                            "identifier": "ANTI_JAM_MODE",
-                                                                                "inputs": [ {
-                                                                                              "description": "switch to previous or next state",
-                                                                                                "interface": "fixed_step"
-                                                                                          }, {
-                                                                                              "description": "set position",
-                                                                                                "interface": "set_state",
-                                                                                                "max_value": 7
-                                                                                          } ],
-                                                                   "momentary_positions": "none",
-                                                                               "outputs": [ {
-                                                                                                  "address": 17922,
-                                                                                              "description": "selector position",
-                                                                                                     "mask": 7,
-                                                                                                "max_value": 7,
-                                                                                                 "shift_by": 0,
-                                                                                                   "suffix": "",
-                                                                                                     "type": "integer"
-                                                                                          } ],
-                                                                      "physical_variant": "limited_rotary"
-                                                               },
-                                                   "IFF_CODE": {
-                                                                              "category": "Radar",
-                                                                          "control_type": "selector",
-                                                                           "description": "IFF Code",
-                                                                            "identifier": "IFF_CODE",
-                                                                                "inputs": [ {
-                                                                                              "description": "switch to previous or next state",
-                                                                                                "interface": "fixed_step"
-                                                                                          }, {
-                                                                                              "description": "set position",
-                                                                                                "interface": "set_state",
-                                                                                                "max_value": 10
-                                                                                          } ],
-                                                                   "momentary_positions": "none",
-                                                                               "outputs": [ {
-                                                                                                  "address": 18066,
-                                                                                              "description": "selector position",
-                                                                                                     "mask": 61440,
-                                                                                                "max_value": 10,
-                                                                                                 "shift_by": 12,
-                                                                                                   "suffix": "",
-                                                                                                     "type": "integer"
-                                                                                          } ],
-                                                                      "physical_variant": "limited_rotary"
-                                                               },
-                                                  "IFF_POWER": {
-                                                                              "category": "Radar",
-                                                                          "control_type": "selector",
-                                                                           "description": "IFF Power",
-                                                                            "identifier": "IFF_POWER",
-                                                                                "inputs": [ {
-                                                                                              "description": "switch to previous or next state",
-                                                                                                "interface": "fixed_step"
-                                                                                          }, {
-                                                                                              "description": "set position",
-                                                                                                "interface": "set_state",
-                                                                                                "max_value": 1
-                                                                                          }, {
-                                                                                                 "argument": "TOGGLE",
-                                                                                              "description": "Toggle switch state",
-                                                                                                "interface": "action"
-                                                                                          } ],
-                                                                   "momentary_positions": "none",
-                                                                               "outputs": [ {
-                                                                                                  "address": 18066,
-                                                                                              "description": "selector position",
-                                                                                                     "mask": 2048,
-                                                                                                "max_value": 1,
-                                                                                                 "shift_by": 11,
-                                                                                                   "suffix": "",
-                                                                                                     "type": "integer"
-                                                                                          } ],
-                                                                      "physical_variant": "toggle_switch"
-                                                               },
-                                               "RADAR_BRIGHT": {
-                                                                       "category": "Radar",
-                                                                   "control_type": "limited_dial",
-                                                                    "description": "Radar Brightness",
-                                                                     "identifier": "RADAR_BRIGHT",
-                                                                         "inputs": [ {
-                                                                                       "description": "set the position of the dial",
-                                                                                         "interface": "set_state",
-                                                                                         "max_value": 65535
-                                                                                   }, {
-                                                                                          "description": "turn the dial left or right",
-                                                                                            "interface": "variable_step",
-                                                                                            "max_value": 65535,
-                                                                                       "suggested_step": 3200
-                                                                                   } ],
-                                                                        "outputs": [ {
-                                                                                           "address": 18080,
-                                                                                       "description": "position of the potentiometer",
-                                                                                              "mask": 65535,
-                                                                                         "max_value": 65535,
-                                                                                          "shift_by": 0,
-                                                                                            "suffix": "",
-                                                                                              "type": "integer"
-                                                                                   } ]
-                                                               },
-                                                 "RADAR_GAIN": {
-                                                                              "category": "Radar",
-                                                                          "control_type": "selector",
-                                                                           "description": "Lin/Log Radar Gain Switch",
-                                                                            "identifier": "RADAR_GAIN",
-                                                                                "inputs": [ {
-                                                                                              "description": "switch to previous or next state",
-                                                                                                "interface": "fixed_step"
-                                                                                          }, {
-                                                                                              "description": "set position",
-                                                                                                "interface": "set_state",
-                                                                                                "max_value": 1
-                                                                                          }, {
-                                                                                                 "argument": "TOGGLE",
-                                                                                              "description": "Toggle switch state",
-                                                                                                "interface": "action"
-                                                                                          } ],
-                                                                   "momentary_positions": "none",
-                                                                               "outputs": [ {
-                                                                                                  "address": 17920,
-                                                                                              "description": "selector position",
-                                                                                                     "mask": 16384,
-                                                                                                "max_value": 1,
-                                                                                                 "shift_by": 14,
-                                                                                                   "suffix": "",
-                                                                                                     "type": "integer"
-                                                                                          } ],
-                                                                      "physical_variant": "toggle_switch"
-                                                               },
-                                               "RADAR_IFF_ID": {
-                                                                           "api_variant": "momentary_last_position",
-                                                                              "category": "Radar",
-                                                                          "control_type": "selector",
-                                                                           "description": "IFF Identification",
-                                                                            "identifier": "RADAR_IFF_ID",
-                                                                                "inputs": [ {
-                                                                                              "description": "switch to previous or next state",
-                                                                                                "interface": "fixed_step"
-                                                                                          }, {
-                                                                                              "description": "set position",
-                                                                                                "interface": "set_state",
-                                                                                                "max_value": 1
-                                                                                          }, {
-                                                                                                 "argument": "TOGGLE",
-                                                                                              "description": "Toggle switch state",
-                                                                                                "interface": "action"
-                                                                                          } ],
-                                                                   "momentary_positions": "none",
-                                                                               "outputs": [ {
-                                                                                                  "address": 17922,
-                                                                                              "description": "selector position",
-                                                                                                     "mask": 64,
-                                                                                                "max_value": 1,
-                                                                                                 "shift_by": 6,
-                                                                                                   "suffix": "",
-                                                                                                     "type": "integer"
-                                                                                          } ],
-                                                                      "physical_variant": "push_button"
-                                                               },
-                                       "RADAR_IGNITION_COILS": {
-                                                                              "category": "Radar",
-                                                                          "control_type": "selector",
-                                                                           "description": "Ignition Coils",
-                                                                            "identifier": "RADAR_IGNITION_COILS",
-                                                                                "inputs": [ {
-                                                                                              "description": "switch to previous or next state",
-                                                                                                "interface": "fixed_step"
-                                                                                          }, {
-                                                                                              "description": "set position",
-                                                                                                "interface": "set_state",
-                                                                                                "max_value": 1
-                                                                                          }, {
-                                                                                                 "argument": "TOGGLE",
-                                                                                              "description": "Toggle switch state",
-                                                                                                "interface": "action"
-                                                                                          } ],
-                                                                   "momentary_positions": "none",
-                                                                               "outputs": [ {
-                                                                                                  "address": 17922,
-                                                                                              "description": "selector position",
-                                                                                                     "mask": 32,
-                                                                                                "max_value": 1,
-                                                                                                 "shift_by": 5,
-                                                                                                   "suffix": "",
-                                                                                                     "type": "integer"
-                                                                                          } ],
-                                                                      "physical_variant": "toggle_switch"
-                                                               },
-                                     "RADAR_MAINTENANCE_TEST": {
-                                                                              "category": "Radar",
-                                                                          "control_type": "selector",
-                                                                           "description": "Radar/EL Maintenance Test",
-                                                                            "identifier": "RADAR_MAINTENANCE_TEST",
-                                                                                "inputs": [ {
-                                                                                              "description": "switch to previous or next state",
-                                                                                                "interface": "fixed_step"
-                                                                                          }, {
-                                                                                              "description": "set position",
-                                                                                                "interface": "set_state",
-                                                                                                "max_value": 1
-                                                                                          }, {
-                                                                                                 "argument": "TOGGLE",
-                                                                                              "description": "Toggle switch state",
-                                                                                                "interface": "action"
-                                                                                          } ],
-                                                                   "momentary_positions": "none",
-                                                                               "outputs": [ {
-                                                                                                  "address": 17922,
-                                                                                              "description": "selector position",
-                                                                                                     "mask": 16,
-                                                                                                "max_value": 1,
-                                                                                                 "shift_by": 4,
-                                                                                                   "suffix": "",
-                                                                                                     "type": "integer"
-                                                                                          } ],
-                                                                      "physical_variant": "toggle_switch"
-                                                               },
-                                   "RADAR_PULSE_NORMAL_SHORT": {
-                                                                              "category": "Radar",
-                                                                          "control_type": "selector",
-                                                                           "description": "Pulse Normal/Short Switch",
-                                                                            "identifier": "RADAR_PULSE_NORMAL_SHORT",
-                                                                                "inputs": [ {
-                                                                                              "description": "switch to previous or next state",
-                                                                                                "interface": "fixed_step"
-                                                                                          }, {
-                                                                                              "description": "set position",
-                                                                                                "interface": "set_state",
-                                                                                                "max_value": 1
-                                                                                          }, {
-                                                                                                 "argument": "TOGGLE",
-                                                                                              "description": "Toggle switch state",
-                                                                                                "interface": "action"
-                                                                                          } ],
-                                                                   "momentary_positions": "none",
-                                                                               "outputs": [ {
-                                                                                                  "address": 17920,
-                                                                                              "description": "selector position",
-                                                                                                     "mask": 32768,
-                                                                                                "max_value": 1,
-                                                                                                 "shift_by": 15,
-                                                                                                   "suffix": "",
-                                                                                                     "type": "integer"
-                                                                                          } ],
-                                                                      "physical_variant": "toggle_switch"
-                                                               },
-                                         "RADAR_RECCE_ON_OFF": {
-                                                                              "category": "Radar",
-                                                                          "control_type": "selector",
-                                                                           "description": "Passive Recce On/Off Switch",
-                                                                            "identifier": "RADAR_RECCE_ON_OFF",
-                                                                                "inputs": [ {
-                                                                                              "description": "switch to previous or next state",
-                                                                                                "interface": "fixed_step"
-                                                                                          }, {
-                                                                                              "description": "set position",
-                                                                                                "interface": "set_state",
-                                                                                                "max_value": 1
-                                                                                          }, {
-                                                                                                 "argument": "TOGGLE",
-                                                                                              "description": "Toggle switch state",
-                                                                                                "interface": "action"
-                                                                                          } ],
-                                                                   "momentary_positions": "none",
-                                                                               "outputs": [ {
-                                                                                                  "address": 17922,
-                                                                                              "description": "selector position",
-                                                                                                     "mask": 8,
-                                                                                                "max_value": 1,
-                                                                                                 "shift_by": 3,
-                                                                                                   "suffix": "",
-                                                                                                     "type": "integer"
-                                                                                          } ],
-                                                                      "physical_variant": "toggle_switch"
-                                                               }
-                               },
-            "Radar Altimeter": {
-                                   "RADAR_ALTIMETER_POWER": {
-                                                                           "category": "Radar Altimeter",
-                                                                       "control_type": "selector",
-                                                                        "description": "Radar Altimeter Power",
-                                                                         "identifier": "RADAR_ALTIMETER_POWER",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 17936,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 1,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 0,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "toggle_switch"
-                                                            }
-                               },
-           "Raw Gauge Values": {
-                                           "ADI_AOA_INDICATOR": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "ADI AoA Indicator",
-                                                                      "identifier": "ADI_AOA_INDICATOR",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 18004,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                                 "ADI_HEADING": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "ADI Heading",
-                                                                      "identifier": "ADI_HEADING",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17992,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                          "ADI_HORIZONTAL_ILS": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "ADI Horizontal ILS",
-                                                                      "identifier": "ADI_HORIZONTAL_ILS",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 18000,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                                   "ADI_PITCH": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "ADI Pitch",
-                                                                      "identifier": "ADI_PITCH",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17990,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                                    "ADI_ROLL": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "ADI Roll",
-                                                                      "identifier": "ADI_ROLL",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17994,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                                "ADI_SLIPBALL": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "ADI Slipball",
-                                                                      "identifier": "ADI_SLIPBALL",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 18002,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                            "ADI_VERTICAL_ILS": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "ADI Vertical ILS",
-                                                                      "identifier": "ADI_VERTICAL_ILS",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17998,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                       "ADI_VERTICAL_VELOCITY": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "ADI Vertical Velocity",
-                                                                      "identifier": "ADI_VERTICAL_VELOCITY",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17996,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                                "AIRSPEED_M/S": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Airspeed m/s",
-                                                                      "identifier": "AIRSPEED_M/S",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17968,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                            "ALTIMETER_10000M": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Altimeter 10000 Meter",
-                                                                      "identifier": "ALTIMETER_10000M",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17978,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                             "ALTIMETER_1000M": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Altimeter 1000 Meter",
-                                                                      "identifier": "ALTIMETER_1000M",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17980,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                     "ALTIMETER_BARO_1000_HPA": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Altimeter Baro 1000 hPa X000",
-                                                                      "identifier": "ALTIMETER_BARO_1000_HPA",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17988,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                      "ALTIMETER_BARO_100_HPA": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Altimeter Baro 100 hPa 0X00",
-                                                                      "identifier": "ALTIMETER_BARO_100_HPA",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17986,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                       "ALTIMETER_BARO_10_HPA": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Altimeter Baro 10 hPa 00X0",
-                                                                      "identifier": "ALTIMETER_BARO_10_HPA",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17984,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                        "ALTIMETER_BARO_1_HPA": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Altimeter Baro 1 hPa 000X",
-                                                                      "identifier": "ALTIMETER_BARO_1_HPA",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17982,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                     "BACKUP_ALTIMETER_10000M": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Backup Altimeter 10000 Meter",
-                                                                      "identifier": "BACKUP_ALTIMETER_10000M",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 18014,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                      "BACKUP_ALTIMETER_1000M": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Backup Altimeter 1000 Meter",
-                                                                      "identifier": "BACKUP_ALTIMETER_1000M",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 18016,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                   "BACKUP_INDICATED_AIRSPEED": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Backup Indicated Airspeed",
-                                                                      "identifier": "BACKUP_INDICATED_AIRSPEED",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 18012,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                                "BACKUP_PITCH": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Backup Pitch",
-                                                                      "identifier": "BACKUP_PITCH",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 18018,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                                 "BACKUP_ROLL": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Backup Roll",
-                                                                      "identifier": "BACKUP_ROLL",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 18020,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                        "CI_COMMANDED_HEADING": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "CI Commanded Heading",
-                                                                      "identifier": "CI_COMMANDED_HEADING",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 18008,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                                  "CI_HEADING": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "CI Heading",
-                                                                      "identifier": "CI_HEADING",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 18006,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                          "DISTANCE_INDICATOR": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Distance Indicator",
-                                                                      "identifier": "DISTANCE_INDICATOR",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 18022,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                               "ENGINE_RPM_10": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Engine RPM 10",
-                                                                      "identifier": "ENGINE_RPM_10",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17964,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                              "ENGINE_RPM_100": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Engine RPM 100",
-                                                                      "identifier": "ENGINE_RPM_100",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17962,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                                 "ENGINE_TEMP": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Engine Temp",
-                                                                      "identifier": "ENGINE_TEMP",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17966,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                                  "FUEL_LEVEL": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Fuel Level",
-                                                                      "identifier": "FUEL_LEVEL",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 18024,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                                 "FUEL_NEEDED": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Fuel Needed",
-                                                                      "identifier": "FUEL_NEEDED",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 18026,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                    "MACH_METER_FIRST_DECIMAL": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Mach Meter First Decimal 0.X0",
-                                                                      "identifier": "MACH_METER_FIRST_DECIMAL",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17972,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                          "MACH_METER_INTEGER": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Mach Meter Integer X.00",
-                                                                      "identifier": "MACH_METER_INTEGER",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17970,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                   "MACH_METER_SECOND_DECIMAL": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Mach Meter Second Decimal 0.0X",
-                                                                      "identifier": "MACH_METER_SECOND_DECIMAL",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17974,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                            "MAGNETIC_HEADING": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Magnetic Heading",
-                                                                      "identifier": "MAGNETIC_HEADING",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 18010,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                                      "PEDALS": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Pedals",
-                                                                      "identifier": "PEDALS",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17958,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                                 "STICK_PITCH": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Stick Pitch",
-                                                                      "identifier": "STICK_PITCH",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17954,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                                  "STICK_ROLL": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Stick Roll",
-                                                                      "identifier": "STICK_ROLL",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17956,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                                    "THROTTLE": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Throttle",
-                                                                      "identifier": "THROTTLE",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17960,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                },
-                                       "VERTICAL_ACCELERATION": {
-                                                                        "category": "Raw Gauge Values",
-                                                                    "control_type": "analog_gauge",
-                                                                     "description": "Vertical Acceleration G Meter",
-                                                                      "identifier": "VERTICAL_ACCELERATION",
-                                                                          "inputs": [  ],
-                                                                         "outputs": [ {
-                                                                                            "address": 17976,
-                                                                                        "description": "gauge position",
-                                                                                               "mask": 65535,
-                                                                                          "max_value": 65535,
-                                                                                           "shift_by": 0,
-                                                                                             "suffix": "",
-                                                                                               "type": "integer"
-                                                                                    } ]
-                                                                }
-                               },
-            "Thrust Reverser": {
-                                   "REVERSAL": {
-                                                              "category": "Thrust Reverser",
-                                                          "control_type": "selector",
-                                                           "description": "Thrust Reverser On/Off",
-                                                            "identifier": "REVERSAL",
-                                                                "inputs": [ {
-                                                                              "description": "switch to previous or next state",
-                                                                                "interface": "fixed_step"
-                                                                          }, {
-                                                                              "description": "set position",
-                                                                                "interface": "set_state",
-                                                                                "max_value": 1
-                                                                          }, {
-                                                                                 "argument": "TOGGLE",
-                                                                              "description": "Toggle switch state",
-                                                                                "interface": "action"
-                                                                          } ],
-                                                   "momentary_positions": "none",
-                                                               "outputs": [ {
-                                                                                  "address": 17922,
-                                                                              "description": "selector position",
-                                                                                     "mask": 128,
-                                                                                "max_value": 1,
-                                                                                 "shift_by": 7,
-                                                                                   "suffix": "",
-                                                                                     "type": "integer"
-                                                                          } ],
-                                                      "physical_variant": "toggle_switch"
-                                               }
-                               },
-              "Warning Panel": {
-                                   "INDICATOR_SYSTEM_TEST": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "Warning Panel",
-                                                                       "control_type": "selector",
-                                                                        "description": "Indicator System Test",
-                                                                         "identifier": "INDICATOR_SYSTEM_TEST",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 17942,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 512,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 9,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            },
-                                    "MASTER_CAUTION_RESET": {
-                                                                           "category": "Warning Panel",
-                                                                       "control_type": "selector",
-                                                                        "description": "Master Caution Reset",
-                                                                         "identifier": "MASTER_CAUTION_RESET",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 17942,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 1024,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 10,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "toggle_switch"
-                                                            },
-                                      "WARNING_PANEL_TEST": {
-                                                                        "api_variant": "momentary_last_position",
-                                                                           "category": "Warning Panel",
-                                                                       "control_type": "selector",
-                                                                        "description": "Warning Panel Light Test",
-                                                                         "identifier": "WARNING_PANEL_TEST",
-                                                                             "inputs": [ {
-                                                                                           "description": "switch to previous or next state",
-                                                                                             "interface": "fixed_step"
-                                                                                       }, {
-                                                                                           "description": "set position",
-                                                                                             "interface": "set_state",
-                                                                                             "max_value": 1
-                                                                                       }, {
-                                                                                              "argument": "TOGGLE",
-                                                                                           "description": "Toggle switch state",
-                                                                                             "interface": "action"
-                                                                                       } ],
-                                                                "momentary_positions": "none",
-                                                                            "outputs": [ {
-                                                                                               "address": 17942,
-                                                                                           "description": "selector position",
-                                                                                                  "mask": 256,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 8,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ],
-                                                                   "physical_variant": "push_button"
-                                                            }
-                               },
-              "Weapon System": {
-                                           "RB_BK_REL_MODE": {
-                                                                            "category": "Weapon System",
-                                                                        "control_type": "selector",
-                                                                         "description": "RB-04/RB-15/BK Release Mode Switch",
-                                                                          "identifier": "RB_BK_REL_MODE",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17920,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 8192,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 13,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                             "TANK_RELEASE": {
-                                                                         "api_variant": "momentary_last_position",
-                                                                            "category": "Weapon System",
-                                                                        "control_type": "selector",
-                                                                         "description": "External Tank Release Button",
-                                                                          "identifier": "TANK_RELEASE",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17920,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 16,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 4,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "push_button"
-                                                             },
-                                       "TANK_RELEASE_COVER": {
-                                                                            "category": "Weapon System",
-                                                                        "control_type": "selector",
-                                                                         "description": "External Tank Release Cover",
-                                                                          "identifier": "TANK_RELEASE_COVER",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17920,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 8,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 3,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                   "TRIGGER_SAFETY_BRACKET": {
-                                                                            "category": "Weapon System",
-                                                                        "control_type": "selector",
-                                                                         "description": "Trigger Safety Bracket",
-                                                                          "identifier": "TRIGGER_SAFETY_BRACKET",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17920,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 1,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 0,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                          "WEAPON_INTERVAL": {
-                                                                            "category": "Weapon System",
-                                                                        "control_type": "selector",
-                                                                         "description": "Weapon Interval Selector Mode Knob",
-                                                                          "identifier": "WEAPON_INTERVAL",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 10
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17920,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 3840,
-                                                                                              "max_value": 10,
-                                                                                               "shift_by": 8,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "limited_rotary"
-                                                             },
-                                           "WEAPON_RELEASE": {
-                                                                         "api_variant": "momentary_last_position",
-                                                                            "category": "Weapon System",
-                                                                        "control_type": "selector",
-                                                                         "description": "Weapon Emergency Release Button",
-                                                                          "identifier": "WEAPON_RELEASE",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17920,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 4,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 2,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "push_button"
-                                                             },
-                                     "WEAPON_RELEASE_COVER": {
-                                                                            "category": "Weapon System",
-                                                                        "control_type": "selector",
-                                                                         "description": "Weapon Emergency Release Cover",
-                                                                          "identifier": "WEAPON_RELEASE_COVER",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17920,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 2,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 1,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                          "WEAPON_REL_MODE": {
-                                                                            "category": "Weapon System",
-                                                                        "control_type": "selector",
-                                                                         "description": "Weapon Release Mode Switch",
-                                                                          "identifier": "WEAPON_REL_MODE",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 1
-                                                                                        }, {
-                                                                                               "argument": "TOGGLE",
-                                                                                            "description": "Toggle switch state",
-                                                                                              "interface": "action"
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17920,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 4096,
-                                                                                              "max_value": 1,
-                                                                                               "shift_by": 12,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "toggle_switch"
-                                                             },
-                                            "WEAPON_SELECT": {
-                                                                            "category": "Weapon System",
-                                                                        "control_type": "selector",
-                                                                         "description": "Weapon Selector Knob",
-                                                                          "identifier": "WEAPON_SELECT",
-                                                                              "inputs": [ {
-                                                                                            "description": "switch to previous or next state",
-                                                                                              "interface": "fixed_step"
-                                                                                        }, {
-                                                                                            "description": "set position",
-                                                                                              "interface": "set_state",
-                                                                                              "max_value": 5
-                                                                                        } ],
-                                                                 "momentary_positions": "none",
-                                                                             "outputs": [ {
-                                                                                                "address": 17920,
-                                                                                            "description": "selector position",
-                                                                                                   "mask": 224,
-                                                                                              "max_value": 5,
-                                                                                               "shift_by": 5,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ],
-                                                                    "physical_variant": "limited_rotary"
-                                                             }
-                               }
+  "Countermeasures": {
+    "COUNTERMEASURE_CHAFF_FLARES_SELECTOR": {
+      "category": "Countermeasures",
+      "control_type": "selector",
+      "description": "Countermeasure Chaff/Flares Selector",
+      "identifier": "COUNTERMEASURE_CHAFF_FLARES_SELECTOR",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 2
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17944,
+          "description": "selector position",
+          "mask": 192,
+          "max_value": 2,
+          "shift_by": 6,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "COUNTERMEASURE_MODE_SELECTOR": {
+      "category": "Countermeasures",
+      "control_type": "selector",
+      "description": "Countermeasure Operation Mode Selector",
+      "identifier": "COUNTERMEASURE_MODE_SELECTOR",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 4
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17944,
+          "description": "selector position",
+          "mask": 56,
+          "max_value": 4,
+          "shift_by": 3,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "COUNTERMEASURE_RELEASE_MODE": {
+      "category": "Countermeasures",
+      "control_type": "selector",
+      "description": "Countermeasure Release Mode",
+      "identifier": "COUNTERMEASURE_RELEASE_MODE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 2
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17944,
+          "description": "selector position",
+          "mask": 768,
+          "max_value": 2,
+          "shift_by": 8,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "COUNTERMEASURE_STREAK_MODE_SELECTOR": {
+      "category": "Countermeasures",
+      "control_type": "selector",
+      "description": "Countermeasure Streak Mode Selector",
+      "identifier": "COUNTERMEASURE_STREAK_MODE_SELECTOR",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17942,
+          "description": "selector position",
+          "mask": 16384,
+          "max_value": 1,
+          "shift_by": 14,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "JAMMER_BAND_SELECTOR": {
+      "category": "Countermeasures",
+      "control_type": "selector",
+      "description": "Jammer Band Selector",
+      "identifier": "JAMMER_BAND_SELECTOR",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 4
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17944,
+          "description": "selector position",
+          "mask": 7,
+          "max_value": 4,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "JAMMER_MODE_SELECTOR": {
+      "category": "Countermeasures",
+      "control_type": "selector",
+      "description": "Jammer Mode Selector",
+      "identifier": "JAMMER_MODE_SELECTOR",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 4
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17942,
+          "description": "selector position",
+          "mask": 14336,
+          "max_value": 4,
+          "shift_by": 11,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    }
+  },
+  "Doppler": {
+    "DOPPLER_LAND_SEA_MODE": {
+      "category": "Doppler",
+      "control_type": "action",
+      "description": "Doppler Land/Sea Mode",
+      "identifier": "DOPPLER_LAND_SEA_MODE",
+      "inputs": [
+        {
+          "argument": "TOGGLE",
+          "description": "toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17936,
+          "description": "selector position",
+          "mask": 2,
+          "max_value": 1,
+          "shift_by": 1,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    }
+  },
+  "Electric System": {
+    "BACKUP_GENERATOR": {
+      "category": "Electric System",
+      "control_type": "selector",
+      "description": "Backup Generator",
+      "identifier": "BACKUP_GENERATOR",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17934,
+          "description": "selector position",
+          "mask": 32768,
+          "max_value": 1,
+          "shift_by": 15,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "GENERATOR": {
+      "category": "Electric System",
+      "control_type": "selector",
+      "description": "Generator",
+      "identifier": "GENERATOR",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17934,
+          "description": "selector position",
+          "mask": 8192,
+          "max_value": 1,
+          "shift_by": 13,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "MAIN_ELECTRIC_POWER": {
+      "category": "Electric System",
+      "control_type": "selector",
+      "description": "Main Electric Power",
+      "identifier": "MAIN_ELECTRIC_POWER",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17934,
+          "description": "selector position",
+          "mask": 16384,
+          "max_value": 1,
+          "shift_by": 14,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    }
+  },
+  "Engine Panel": {
+    "AFK_LEVER": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "AFK Lever",
+      "identifier": "AFK_LEVER",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17934,
+          "description": "selector position",
+          "mask": 1024,
+          "max_value": 1,
+          "shift_by": 10,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "CABIN_AIR_VALVE": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "Cabin Air Valve",
+      "identifier": "CABIN_AIR_VALVE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18076,
+          "description": "selector position",
+          "mask": 1,
+          "max_value": 1,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "CB_AUTOPILOT": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "CB Autopilot SA",
+      "identifier": "CB_AUTOPILOT",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17926,
+          "description": "selector position",
+          "mask": 4096,
+          "max_value": 1,
+          "shift_by": 12,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "CB_CI_SI": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "CB CI/SI",
+      "identifier": "CB_CI_SI",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17926,
+          "description": "selector position",
+          "mask": 32768,
+          "max_value": 1,
+          "shift_by": 15,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "CB_EJECTION_SYSTEM": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "CB Ejection System",
+      "identifier": "CB_EJECTION_SYSTEM",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17934,
+          "description": "selector position",
+          "mask": 1,
+          "max_value": 1,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "CB_ENGINE": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "CB Engine",
+      "identifier": "CB_ENGINE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17934,
+          "description": "selector position",
+          "mask": 2,
+          "max_value": 1,
+          "shift_by": 1,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "CB_HIGH_ALPHA_WARN": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "CB High Alpha Warning",
+      "identifier": "CB_HIGH_ALPHA_WARN",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17926,
+          "description": "selector position",
+          "mask": 8192,
+          "max_value": 1,
+          "shift_by": 13,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "CB_TRIM_SYSTEM": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "CB Trim System",
+      "identifier": "CB_TRIM_SYSTEM",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17926,
+          "description": "selector position",
+          "mask": 16384,
+          "max_value": 1,
+          "shift_by": 14,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "DATA_CARTRIDGE": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "Insert/Remove Data Cartridge",
+      "identifier": "DATA_CARTRIDGE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17934,
+          "description": "selector position",
+          "mask": 2048,
+          "max_value": 1,
+          "shift_by": 11,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "DE-ICE": {
+      "category": "Engine Panel",
+      "control_type": "limited_dial",
+      "description": "Windscreen De-Ice",
+      "identifier": "DE-ICE",
+      "inputs": [
+        {
+          "description": "set the position of the dial",
+          "interface": "set_state",
+          "max_value": 65535
+        },
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 18070,
+          "description": "position of the potentiometer",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "DME_SELECTOR": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "DME Selector",
+      "identifier": "DME_SELECTOR",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17934,
+          "description": "selector position",
+          "mask": 16,
+          "max_value": 1,
+          "shift_by": 4,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "DRYSUIT": {
+      "category": "Engine Panel",
+      "control_type": "limited_dial",
+      "description": "Drysuit Ventilation Adjustment",
+      "identifier": "DRYSUIT",
+      "inputs": [
+        {
+          "description": "set the position of the dial",
+          "interface": "set_state",
+          "max_value": 65535
+        },
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 18074,
+          "description": "position of the potentiometer",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ENGINE_DEICE": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "Engine De-Ice",
+      "identifier": "ENGINE_DEICE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17926,
+          "description": "selector position",
+          "mask": 1024,
+          "max_value": 1,
+          "shift_by": 10,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "FLIGHT_RECORDER": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "Flight Recorder",
+      "identifier": "FLIGHT_RECORDER",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 2
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17934,
+          "description": "selector position",
+          "mask": 384,
+          "max_value": 2,
+          "shift_by": 7,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "HIGH_PRES_FUEL_VALVE": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "High Pressure Fuel Valve",
+      "identifier": "HIGH_PRES_FUEL_VALVE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17926,
+          "description": "selector position",
+          "mask": 512,
+          "max_value": 1,
+          "shift_by": 9,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "IFF_CHANNEL": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "IFF Channel Selector",
+      "identifier": "IFF_CHANNEL",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17934,
+          "description": "selector position",
+          "mask": 8,
+          "max_value": 1,
+          "shift_by": 3,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "IFF_TRANSPONDER_POWER": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "IFF/Transponder Power",
+      "identifier": "IFF_TRANSPONDER_POWER",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17934,
+          "description": "selector position",
+          "mask": 4,
+          "max_value": 1,
+          "shift_by": 2,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "IGNITION_SYSTEM": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "Ignition System",
+      "identifier": "IGNITION_SYSTEM",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17934,
+          "description": "selector position",
+          "mask": 32,
+          "max_value": 1,
+          "shift_by": 5,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "LOW_PRES_FUEL_VALVE": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "Low Pressure Fuel Valve",
+      "identifier": "LOW_PRES_FUEL_VALVE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17926,
+          "description": "selector position",
+          "mask": 256,
+          "max_value": 1,
+          "shift_by": 8,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "MANUAL_FUEL_REG": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "Manual Fuel Regulator",
+      "identifier": "MANUAL_FUEL_REG",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17926,
+          "description": "selector position",
+          "mask": 2048,
+          "max_value": 1,
+          "shift_by": 11,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "MAN_AFTERBURN_FUEL_REG": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "Manual Afterburner Fuel Regulator",
+      "identifier": "MAN_AFTERBURN_FUEL_REG",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17934,
+          "description": "selector position",
+          "mask": 64,
+          "max_value": 1,
+          "shift_by": 6,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "MISSILE_SELECT_BUTTON": {
+      "api_variant": "momentary_last_position",
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "Missile Select Button",
+      "identifier": "MISSILE_SELECT_BUTTON",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17934,
+          "description": "selector position",
+          "mask": 4096,
+          "max_value": 1,
+          "shift_by": 12,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "RESTART": {
+      "api_variant": "momentary_last_position",
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "Restart",
+      "identifier": "RESTART",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17934,
+          "description": "selector position",
+          "mask": 512,
+          "max_value": 1,
+          "shift_by": 9,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "START_SYSTEM": {
+      "category": "Engine Panel",
+      "control_type": "selector",
+      "description": "Start System",
+      "identifier": "START_SYSTEM",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17926,
+          "description": "selector position",
+          "mask": 128,
+          "max_value": 1,
+          "shift_by": 7,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "TEST_MODE": {
+      "category": "Engine Panel",
+      "control_type": "limited_dial",
+      "description": "Maintenance Testing Mode",
+      "identifier": "TEST_MODE",
+      "inputs": [
+        {
+          "description": "set the position of the dial",
+          "interface": "set_state",
+          "max_value": 65535
+        },
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 18072,
+          "description": "position of the potentiometer",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "Error Panel": {
+    "AFK_FEL": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Autothrottle",
+      "identifier": "AFK_FEL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18028,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 4096,
+          "max_value": 1,
+          "shift_by": 12,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "BRAND_1": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Engine Fire 1",
+      "identifier": "BRAND_1",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17944,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 8192,
+          "max_value": 1,
+          "shift_by": 13,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "BRAND_2": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Engine Fire 2",
+      "identifier": "BRAND_2",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17944,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 16384,
+          "max_value": 1,
+          "shift_by": 14,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "BRAND_GTS": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Turbine Starter Fire",
+      "identifier": "BRAND_GTS",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18030,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 2048,
+          "max_value": 1,
+          "shift_by": 11,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "BRA_24": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Low Fuel",
+      "identifier": "BRA_24",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18030,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 1024,
+          "max_value": 1,
+          "shift_by": 10,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "BRA_UPPF": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Fuel Distribution Low Pressure",
+      "identifier": "BRA_UPPF",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17944,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 32768,
+          "max_value": 1,
+          "shift_by": 15,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "CK": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Computer",
+      "identifier": "CK",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18030,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 8,
+          "max_value": 1,
+          "shift_by": 3,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "EJ_REV": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Thrust Reverser Inoperable",
+      "identifier": "EJ_REV",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18028,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 8192,
+          "max_value": 1,
+          "shift_by": 13,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ELFEL": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Electrical System",
+      "identifier": "ELFEL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18028,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 256,
+          "max_value": 1,
+          "shift_by": 8,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "FACKL_SL": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Flares Empty",
+      "identifier": "FACKL_SL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18032,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 1,
+          "max_value": 1,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "FORV_FORB": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Thrust Reverser Warning",
+      "identifier": "FORV_FORB",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18028,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 8,
+          "max_value": 1,
+          "shift_by": 3,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "HALL_FUNK": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Autopilot Hold",
+      "identifier": "HALL_FUNK",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18030,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 1,
+          "max_value": 1,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "HSTALL": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Right Gear",
+      "identifier": "HSTALL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18028,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 64,
+          "max_value": 1,
+          "shift_by": 6,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "HUV_O_STOL": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Ejection Seat/Canopy",
+      "identifier": "HUV_O_STOL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18030,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 32,
+          "max_value": 1,
+          "shift_by": 5,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "HYDRA_TA_1": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Hydraulic System 1 Pressure",
+      "identifier": "HYDRA_TA_1",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18028,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 2048,
+          "max_value": 1,
+          "shift_by": 11,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "HYDRA_TA_2": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Hydraulic System 2 Pressure",
+      "identifier": "HYDRA_TA_2",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18028,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 1024,
+          "max_value": 1,
+          "shift_by": 10,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "KABINHOJD": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Cabin Pressure",
+      "identifier": "KABINHOJD",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18030,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 16,
+          "max_value": 1,
+          "shift_by": 4,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "KB_H_KA_SL": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Right Countermeasures Pod Empty/ECM Failure",
+      "identifier": "KB_H_KA_SL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18030,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 32768,
+          "max_value": 1,
+          "shift_by": 15,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "KB_V_SLUT": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Left Countermeasures Pod Empty",
+      "identifier": "KB_V_SLUT",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18030,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 16384,
+          "max_value": 1,
+          "shift_by": 14,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "LANDSTALL": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Landing Gear",
+      "identifier": "LANDSTALL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18028,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 4,
+          "max_value": 1,
+          "shift_by": 2,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "LUFTBROMS": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Airbrakes",
+      "identifier": "LUFTBROMS",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18032,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 4,
+          "max_value": 1,
+          "shift_by": 2,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "MAN_BG_REG": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Manual Fuel Regulator",
+      "identifier": "MAN_BG_REG",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18030,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 256,
+          "max_value": 1,
+          "shift_by": 8,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "MOTVERK": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Countermeasures/RWR",
+      "identifier": "MOTVERK",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18032,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 2,
+          "max_value": 1,
+          "shift_by": 1,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "NAV_SYST": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Navigation System",
+      "identifier": "NAV_SYST",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18030,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 8192,
+          "max_value": 1,
+          "shift_by": 13,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "NOSSTALL": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Nose Gear",
+      "identifier": "NOSSTALL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18028,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 16,
+          "max_value": 1,
+          "shift_by": 4,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "OLJETRYCK": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Oil Pressure",
+      "identifier": "OLJETRYCK",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18028,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 16384,
+          "max_value": 1,
+          "shift_by": 14,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "RESERVEFF": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Backup Hydraulic",
+      "identifier": "RESERVEFF",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18028,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 512,
+          "max_value": 1,
+          "shift_by": 9,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "RHM_FEL": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Radar Altimeter",
+      "identifier": "RHM_FEL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18030,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 2,
+          "max_value": 1,
+          "shift_by": 1,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ROLL_VAXEL": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Roll Gearing",
+      "identifier": "ROLL_VAXEL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18030,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 4,
+          "max_value": 1,
+          "shift_by": 2,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "SPAK_ERROR": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "SPAK Error",
+      "identifier": "SPAK_ERROR",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18028,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 32768,
+          "max_value": 1,
+          "shift_by": 15,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "STARTSYST": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Starter System",
+      "identifier": "STARTSYST",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18030,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 128,
+          "max_value": 1,
+          "shift_by": 7,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "SYRGAS": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Oxygen",
+      "identifier": "SYRGAS",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18030,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 512,
+          "max_value": 1,
+          "shift_by": 9,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "TANDSYST": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Ignition System",
+      "identifier": "TANDSYST",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18030,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 64,
+          "max_value": 1,
+          "shift_by": 6,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "TANK_PUMP": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Fuel Pump",
+      "identifier": "TANK_PUMP",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18028,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 2,
+          "max_value": 1,
+          "shift_by": 1,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "TILS": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "TILS",
+      "identifier": "TILS",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18030,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 4096,
+          "max_value": 1,
+          "shift_by": 12,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "TIPPVAXEL": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Pitch Gearing",
+      "identifier": "TIPPVAXEL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18028,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 128,
+          "max_value": 1,
+          "shift_by": 7,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "VSTALL": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "Left Gear",
+      "identifier": "VSTALL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18028,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 32,
+          "max_value": 1,
+          "shift_by": 5,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "X_TANK_BRA": {
+      "category": "Error Panel",
+      "control_type": "led",
+      "description": "External Fuel Tank Feed System",
+      "identifier": "X_TANK_BRA",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18028,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 1,
+          "max_value": 1,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "External Aircraft Model": {
+    "EXT_FORMATION_LIGHTS": {
+      "category": "External Aircraft Model",
+      "control_type": "metadata",
+      "description": "Formation Lights",
+      "identifier": "EXT_FORMATION_LIGHTS",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18032,
+          "description": "Formation Lights",
+          "mask": 128,
+          "max_value": 1,
+          "shift_by": 7,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "EXT_NAV_LIGHTS_TAIL": {
+      "category": "External Aircraft Model",
+      "control_type": "metadata",
+      "description": "Navigation Lights Tail",
+      "identifier": "EXT_NAV_LIGHTS_TAIL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18032,
+          "description": "Navigation Lights Tail",
+          "mask": 32,
+          "max_value": 1,
+          "shift_by": 5,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "EXT_NAV_LIGHTS_WING": {
+      "category": "External Aircraft Model",
+      "control_type": "metadata",
+      "description": "Navigation Lights Wing",
+      "identifier": "EXT_NAV_LIGHTS_WING",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18032,
+          "description": "Navigation Lights Wing",
+          "mask": 16,
+          "max_value": 1,
+          "shift_by": 4,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "EXT_POSITION_LIGHTS": {
+      "category": "External Aircraft Model",
+      "control_type": "metadata",
+      "description": "Position Lights",
+      "identifier": "EXT_POSITION_LIGHTS",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18032,
+          "description": "Position Lights",
+          "mask": 8,
+          "max_value": 1,
+          "shift_by": 3,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "EXT_SPEED_BRAKE_LEFT": {
+      "category": "External Aircraft Model",
+      "control_type": "metadata",
+      "description": "Left Speed Brake",
+      "identifier": "EXT_SPEED_BRAKE_LEFT",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18052,
+          "description": "Left Speed Brake",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "EXT_SPEED_BRAKE_RIGHT": {
+      "category": "External Aircraft Model",
+      "control_type": "metadata",
+      "description": "Right Speed Brake",
+      "identifier": "EXT_SPEED_BRAKE_RIGHT",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18050,
+          "description": "Right Speed Brake",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "EXT_STROBE_LIGHTS": {
+      "category": "External Aircraft Model",
+      "control_type": "metadata",
+      "description": "Strobe Lights",
+      "identifier": "EXT_STROBE_LIGHTS",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18032,
+          "description": "Strobe Lights",
+          "mask": 64,
+          "max_value": 1,
+          "shift_by": 6,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "FR22 Radio": {
+    "FR22_BASE": {
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "FR22 Base Selector",
+      "identifier": "FR22_BASE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 10
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18066,
+          "description": "selector position",
+          "mask": 120,
+          "max_value": 10,
+          "shift_by": 3,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "FR22_CHANNEL_AG": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Channel A/G",
+      "identifier": "FR22_CHANNEL_AG",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18064,
+          "description": "selector position",
+          "mask": 1024,
+          "max_value": 1,
+          "shift_by": 10,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_CHANNEL_B": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Channel B",
+      "identifier": "FR22_CHANNEL_B",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18064,
+          "description": "selector position",
+          "mask": 2048,
+          "max_value": 1,
+          "shift_by": 11,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_CHANNEL_C2": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Channel C2",
+      "identifier": "FR22_CHANNEL_C2",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18064,
+          "description": "selector position",
+          "mask": 8192,
+          "max_value": 1,
+          "shift_by": 13,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_CHANNEL_CF": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Channel C/F",
+      "identifier": "FR22_CHANNEL_CF",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18064,
+          "description": "selector position",
+          "mask": 4096,
+          "max_value": 1,
+          "shift_by": 12,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_CHANNEL_DE": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Channel D/E",
+      "identifier": "FR22_CHANNEL_DE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18064,
+          "description": "selector position",
+          "mask": 16384,
+          "max_value": 1,
+          "shift_by": 14,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_CHANNEL_H": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Channel H",
+      "identifier": "FR22_CHANNEL_H",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18064,
+          "description": "selector position",
+          "mask": 32,
+          "max_value": 1,
+          "shift_by": 5,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_FLIGHT_0": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Flight 0",
+      "identifier": "FR22_FLIGHT_0",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18032,
+          "description": "selector position",
+          "mask": 2048,
+          "max_value": 1,
+          "shift_by": 11,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_FLIGHT_1": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Flight 1",
+      "identifier": "FR22_FLIGHT_1",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18032,
+          "description": "selector position",
+          "mask": 4096,
+          "max_value": 1,
+          "shift_by": 12,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_FLIGHT_2": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Flight 2",
+      "identifier": "FR22_FLIGHT_2",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18032,
+          "description": "selector position",
+          "mask": 8192,
+          "max_value": 1,
+          "shift_by": 13,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_FLIGHT_3": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Flight 3",
+      "identifier": "FR22_FLIGHT_3",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18032,
+          "description": "selector position",
+          "mask": 16384,
+          "max_value": 1,
+          "shift_by": 14,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_FLIGHT_4": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Flight 4",
+      "identifier": "FR22_FLIGHT_4",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18032,
+          "description": "selector position",
+          "mask": 32768,
+          "max_value": 1,
+          "shift_by": 15,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_FLIGHT_5": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Flight 5",
+      "identifier": "FR22_FLIGHT_5",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18064,
+          "description": "selector position",
+          "mask": 1,
+          "max_value": 1,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_FLIGHT_6": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Flight 6",
+      "identifier": "FR22_FLIGHT_6",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18064,
+          "description": "selector position",
+          "mask": 2,
+          "max_value": 1,
+          "shift_by": 1,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_FLIGHT_7": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Flight 7",
+      "identifier": "FR22_FLIGHT_7",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18064,
+          "description": "selector position",
+          "mask": 4,
+          "max_value": 1,
+          "shift_by": 2,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_FLIGHT_8": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Flight 8",
+      "identifier": "FR22_FLIGHT_8",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18064,
+          "description": "selector position",
+          "mask": 8,
+          "max_value": 1,
+          "shift_by": 3,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_FLIGHT_9": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Flight 9",
+      "identifier": "FR22_FLIGHT_9",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18064,
+          "description": "selector position",
+          "mask": 16,
+          "max_value": 1,
+          "shift_by": 4,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_GROUND_COM": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Ground Intercom",
+      "identifier": "FR22_GROUND_COM",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18064,
+          "description": "selector position",
+          "mask": 32768,
+          "max_value": 1,
+          "shift_by": 15,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_GROUP": {
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "FR22 Group Selector",
+      "identifier": "FR22_GROUP",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 10
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18066,
+          "description": "selector position",
+          "mask": 1920,
+          "max_value": 10,
+          "shift_by": 7,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "FR22_INNER_LEFT_KNOB": {
+      "api_variant": "multiturn",
+      "category": "FR22 Radio",
+      "control_type": "analog_dial",
+      "description": "Radio Frequency Knob Inner Left",
+      "identifier": "FR22_INNER_LEFT_KNOB",
+      "inputs": [
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 17946,
+          "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "_KNOB_POS",
+          "type": "integer"
+        }
+      ]
+    },
+    "FR22_INNER_RIGHT_KNOB": {
+      "api_variant": "multiturn",
+      "category": "FR22 Radio",
+      "control_type": "analog_dial",
+      "description": "Radio Frequency Knob Inner Right",
+      "identifier": "FR22_INNER_RIGHT_KNOB",
+      "inputs": [
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 17950,
+          "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "_KNOB_POS",
+          "type": "integer"
+        }
+      ]
+    },
+    "FR22_MINUS": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Minus",
+      "identifier": "FR22_MINUS",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18064,
+          "description": "selector position",
+          "mask": 512,
+          "max_value": 1,
+          "shift_by": 9,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_MODE": {
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "FR22 Mode Selector",
+      "identifier": "FR22_MODE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 5
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18066,
+          "description": "selector position",
+          "mask": 7,
+          "max_value": 5,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "FR22_OUTER_LEFT_KNOB": {
+      "api_variant": "multiturn",
+      "category": "FR22 Radio",
+      "control_type": "analog_dial",
+      "description": "Radio Frequency Knob Outer Left",
+      "identifier": "FR22_OUTER_LEFT_KNOB",
+      "inputs": [
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 17948,
+          "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "_KNOB_POS",
+          "type": "integer"
+        }
+      ]
+    },
+    "FR22_OUTER_RIGHT_KNOB": {
+      "api_variant": "multiturn",
+      "category": "FR22 Radio",
+      "control_type": "analog_dial",
+      "description": "Radio Frequency Knob Outer Right",
+      "identifier": "FR22_OUTER_RIGHT_KNOB",
+      "inputs": [
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 17952,
+          "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "_KNOB_POS",
+          "type": "integer"
+        }
+      ]
+    },
+    "FR22_SET_MODULATION": {
+      "category": "FR22 Radio",
+      "control_type": "action",
+      "description": "Radio Manual Frequency Setting Modulation",
+      "identifier": "FR22_SET_MODULATION",
+      "inputs": [
+        {
+          "argument": "TOGGLE",
+          "description": "toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17942,
+          "description": "selector position",
+          "mask": 32768,
+          "max_value": 1,
+          "shift_by": 15,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "FR22_SPECIAL_1": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Special 1",
+      "identifier": "FR22_SPECIAL_1",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18064,
+          "description": "selector position",
+          "mask": 64,
+          "max_value": 1,
+          "shift_by": 6,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_SPECIAL_2": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Special 2",
+      "identifier": "FR22_SPECIAL_2",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18064,
+          "description": "selector position",
+          "mask": 128,
+          "max_value": 1,
+          "shift_by": 7,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_SPECIAL_3": {
+      "api_variant": "momentary_last_position",
+      "category": "FR22 Radio",
+      "control_type": "selector",
+      "description": "Special 3",
+      "identifier": "FR22_SPECIAL_3",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18064,
+          "description": "selector position",
+          "mask": 256,
+          "max_value": 1,
+          "shift_by": 8,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "FR22_VOL": {
+      "api_variant": "multiturn",
+      "category": "FR22 Radio",
+      "control_type": "analog_dial",
+      "description": "Radio Volume",
+      "identifier": "FR22_VOL",
+      "inputs": [
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 18068,
+          "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "_KNOB_POS",
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "Flight Data Unit": {
+    "AFK_15_DEG_MODE": {
+      "category": "Flight Data Unit",
+      "control_type": "action",
+      "description": "AFK 15 Deg Mode",
+      "identifier": "AFK_15_DEG_MODE",
+      "inputs": [
+        {
+          "argument": "TOGGLE",
+          "description": "toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17940,
+          "description": "selector position",
+          "mask": 4096,
+          "max_value": 1,
+          "shift_by": 12,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "AFK_MODE_3": {
+      "category": "Flight Data Unit",
+      "control_type": "action",
+      "description": "AFK Mode 3",
+      "identifier": "AFK_MODE_3",
+      "inputs": [
+        {
+          "argument": "TOGGLE",
+          "description": "toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17940,
+          "description": "selector position",
+          "mask": 2048,
+          "max_value": 1,
+          "shift_by": 11,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "ALTITUDE_HOLD": {
+      "api_variant": "momentary_last_position",
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Altitude Hold",
+      "identifier": "ALTITUDE_HOLD",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17936,
+          "description": "selector position",
+          "mask": 32,
+          "max_value": 1,
+          "shift_by": 5,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "ALT_SET": {
+      "category": "Flight Data Unit",
+      "control_type": "limited_dial",
+      "description": "Altimeter Setting",
+      "identifier": "ALT_SET",
+      "inputs": [
+        {
+          "description": "set the position of the dial",
+          "interface": "set_state",
+          "max_value": 65535
+        },
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 18054,
+          "description": "position of the potentiometer",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ATTITUDE_HOLD": {
+      "api_variant": "momentary_last_position",
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Attitude Hold",
+      "identifier": "ATTITUDE_HOLD",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17936,
+          "description": "selector position",
+          "mask": 16,
+          "max_value": 1,
+          "shift_by": 4,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "AUTO_YAW_TRIM": {
+      "category": "Flight Data Unit",
+      "control_type": "limited_dial",
+      "description": "Autopilot Yaw Trim",
+      "identifier": "AUTO_YAW_TRIM",
+      "inputs": [
+        {
+          "description": "set the position of the dial",
+          "interface": "set_state",
+          "max_value": 65535
+        },
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 18060,
+          "description": "position of the potentiometer",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "BACKUP_ALT_SETTING": {
+      "category": "Flight Data Unit",
+      "control_type": "limited_dial",
+      "description": "Backup Altimeter Setting",
+      "identifier": "BACKUP_ALT_SETTING",
+      "inputs": [
+        {
+          "description": "set the position of the dial",
+          "interface": "set_state",
+          "max_value": 65535
+        },
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 17938,
+          "description": "position of the potentiometer",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "BACK_ADI_CAGE": {
+      "api_variant": "momentary_last_position",
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Backup ADI Cage",
+      "identifier": "BACK_ADI_CAGE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18032,
+          "description": "selector position",
+          "mask": 512,
+          "max_value": 1,
+          "shift_by": 9,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "CANOPY_JETTISON": {
+      "api_variant": "momentary_last_position",
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Canopy Jettison",
+      "identifier": "CANOPY_JETTISON",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17940,
+          "description": "selector position",
+          "mask": 4,
+          "max_value": 1,
+          "shift_by": 2,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "CANOPY_OPEN_CLOSE": {
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Canopy Open/Close",
+      "identifier": "CANOPY_OPEN_CLOSE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 2
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17940,
+          "description": "selector position",
+          "mask": 3,
+          "max_value": 2,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "CLOCK_SET": {
+      "category": "Flight Data Unit",
+      "control_type": "limited_dial",
+      "description": "Clock Setting",
+      "identifier": "CLOCK_SET",
+      "inputs": [
+        {
+          "description": "set the position of the dial",
+          "interface": "set_state",
+          "max_value": 65535
+        },
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 18062,
+          "description": "position of the potentiometer",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "COUNTERMEASURE_FAST_RELEASE": {
+      "api_variant": "momentary_last_position",
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Countermeasure Fast Release",
+      "identifier": "COUNTERMEASURE_FAST_RELEASE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17940,
+          "description": "selector position",
+          "mask": 8,
+          "max_value": 1,
+          "shift_by": 3,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "EJECTION_SEAT_ARM": {
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Ejection Seat Arm",
+      "identifier": "EJECTION_SEAT_ARM",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17936,
+          "description": "selector position",
+          "mask": 2048,
+          "max_value": 1,
+          "shift_by": 11,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "EMERGENCY_PITCH_TRIM": {
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Emergency Pitch Trim",
+      "identifier": "EMERGENCY_PITCH_TRIM",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17940,
+          "description": "selector position",
+          "mask": 32,
+          "max_value": 1,
+          "shift_by": 5,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "EMERGENCY_ROLL_TRIM": {
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Emergency Roll Trim",
+      "identifier": "EMERGENCY_ROLL_TRIM",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17940,
+          "description": "selector position",
+          "mask": 16,
+          "max_value": 1,
+          "shift_by": 4,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "EMERGENCY_YAW_TRIM": {
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Emergency Yaw Trim",
+      "identifier": "EMERGENCY_YAW_TRIM",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17940,
+          "description": "selector position",
+          "mask": 64,
+          "max_value": 1,
+          "shift_by": 6,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "GEAR_HANDLE": {
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Gear Handle",
+      "identifier": "GEAR_HANDLE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17936,
+          "description": "selector position",
+          "mask": 4,
+          "max_value": 1,
+          "shift_by": 2,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "HOJD_CISI": {
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "HOJD CISI",
+      "identifier": "HOJD_CISI",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17936,
+          "description": "selector position",
+          "mask": 8192,
+          "max_value": 1,
+          "shift_by": 13,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "HUD_BRIGHT": {
+      "category": "Flight Data Unit",
+      "control_type": "limited_dial",
+      "description": "HUD Brightness Knob",
+      "identifier": "HUD_BRIGHT",
+      "inputs": [
+        {
+          "description": "set the position of the dial",
+          "interface": "set_state",
+          "max_value": 65535
+        },
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 18056,
+          "description": "position of the potentiometer",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "HUD_GLASS_POSITION": {
+      "category": "Flight Data Unit",
+      "control_type": "action",
+      "description": "HUD Reflector Glass Position",
+      "identifier": "HUD_GLASS_POSITION",
+      "inputs": [
+        {
+          "argument": "TOGGLE",
+          "description": "toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17940,
+          "description": "selector position",
+          "mask": 1024,
+          "max_value": 1,
+          "shift_by": 10,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "MAG_CORRECTION": {
+      "category": "Flight Data Unit",
+      "control_type": "limited_dial",
+      "description": "Magnetic Declination Correction",
+      "identifier": "MAG_CORRECTION",
+      "inputs": [
+        {
+          "description": "set the position of the dial",
+          "interface": "set_state",
+          "max_value": 65535
+        },
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 18058,
+          "description": "position of the potentiometer",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "MAG_DEC_COVER": {
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Magnetic Declination Cover",
+      "identifier": "MAG_DEC_COVER",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17940,
+          "description": "selector position",
+          "mask": 128,
+          "max_value": 1,
+          "shift_by": 7,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "MASTER_MODE_SELECT": {
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Master Mode Selector",
+      "identifier": "MASTER_MODE_SELECT",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 6
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17940,
+          "description": "selector position",
+          "mask": 57344,
+          "max_value": 6,
+          "shift_by": 13,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "MAX_G_RESET": {
+      "api_variant": "momentary_last_position",
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Max G Reset",
+      "identifier": "MAX_G_RESET",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18032,
+          "description": "selector position",
+          "mask": 256,
+          "max_value": 1,
+          "shift_by": 8,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "OXYGEN_LEVER": {
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Oxygen Lever",
+      "identifier": "OXYGEN_LEVER",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17936,
+          "description": "selector position",
+          "mask": 32768,
+          "max_value": 1,
+          "shift_by": 15,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "PARKING_BRAKE": {
+      "category": "Flight Data Unit",
+      "control_type": "action",
+      "description": "Parking Brake",
+      "identifier": "PARKING_BRAKE",
+      "inputs": [
+        {
+          "argument": "TOGGLE",
+          "description": "toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17940,
+          "description": "selector position",
+          "mask": 512,
+          "max_value": 1,
+          "shift_by": 9,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "PITCH_GEAR_MODE": {
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Pitch Gear Automatic/Landing",
+      "identifier": "PITCH_GEAR_MODE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17936,
+          "description": "selector position",
+          "mask": 16384,
+          "max_value": 1,
+          "shift_by": 14,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "ROLL_CENTER": {
+      "api_variant": "momentary_last_position",
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Roll Centering",
+      "identifier": "ROLL_CENTER",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18032,
+          "description": "selector position",
+          "mask": 1024,
+          "max_value": 1,
+          "shift_by": 10,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "SLAV_SI": {
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Slav SI",
+      "identifier": "SLAV_SI",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17936,
+          "description": "selector position",
+          "mask": 4096,
+          "max_value": 1,
+          "shift_by": 12,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "SPAK": {
+      "api_variant": "momentary_last_position",
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "SPAK",
+      "identifier": "SPAK",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17936,
+          "description": "selector position",
+          "mask": 8,
+          "max_value": 1,
+          "shift_by": 3,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "TILS_CHANNEL_LAYER": {
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "TILS Channel Layer Selection",
+      "identifier": "TILS_CHANNEL_LAYER",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17936,
+          "description": "selector position",
+          "mask": 1024,
+          "max_value": 1,
+          "shift_by": 10,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "TILS_CHANNEL_SELECT": {
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "TILS Channel Selection",
+      "identifier": "TILS_CHANNEL_SELECT",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 10
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17936,
+          "description": "selector position",
+          "mask": 960,
+          "max_value": 10,
+          "shift_by": 6,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "YAW_TRIM_COVER": {
+      "category": "Flight Data Unit",
+      "control_type": "selector",
+      "description": "Autopilot Yaw Trim Cover",
+      "identifier": "YAW_TRIM_COVER",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17940,
+          "description": "selector position",
+          "mask": 256,
+          "max_value": 1,
+          "shift_by": 8,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    }
+  },
+  "Gauge Values": {
+    "AIRSPEED_VALUE": {
+      "category": "Gauge Values",
+      "control_type": "metadata",
+      "description": "Airspeed Value",
+      "identifier": "AIRSPEED_VALUE",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18038,
+          "description": "Airspeed Value",
+          "mask": 65535,
+          "max_value": 65000,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ALTITUDE_VALUE": {
+      "category": "Gauge Values",
+      "control_type": "metadata",
+      "description": "Altitude Value",
+      "identifier": "ALTITUDE_VALUE",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18040,
+          "description": "Altitude Value",
+          "mask": 65535,
+          "max_value": 65000,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "CI_COMMAND_HEADING_VALUE": {
+      "category": "Gauge Values",
+      "control_type": "metadata",
+      "description": "CI Commanded Heading Value",
+      "identifier": "CI_COMMAND_HEADING_VALUE",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18048,
+          "description": "CI Commanded Heading Value",
+          "mask": 65535,
+          "max_value": 65000,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "CI_HEADING_VALUE": {
+      "category": "Gauge Values",
+      "control_type": "metadata",
+      "description": "CI Heading Value",
+      "identifier": "CI_HEADING_VALUE",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18046,
+          "description": "CI Heading Value",
+          "mask": 65535,
+          "max_value": 65000,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ENGINE_RPM_VALUE": {
+      "category": "Gauge Values",
+      "control_type": "metadata",
+      "description": "Engine RPM Value",
+      "identifier": "ENGINE_RPM_VALUE",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18034,
+          "description": "Engine RPM Value",
+          "mask": 65535,
+          "max_value": 65000,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ENGINE_TEMP_VALUE": {
+      "category": "Gauge Values",
+      "control_type": "metadata",
+      "description": "Engine Temp Value",
+      "identifier": "ENGINE_TEMP_VALUE",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18036,
+          "description": "Engine Temp Value",
+          "mask": 65535,
+          "max_value": 65000,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "FUEL_LEVEL_VALUE": {
+      "category": "Gauge Values",
+      "control_type": "metadata",
+      "description": "Fuel Level Value",
+      "identifier": "FUEL_LEVEL_VALUE",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18042,
+          "description": "Fuel Level Value",
+          "mask": 65535,
+          "max_value": 65000,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "FUEL_NEEDED_VALUE": {
+      "category": "Gauge Values",
+      "control_type": "metadata",
+      "description": "Fuel Needed Value",
+      "identifier": "FUEL_NEEDED_VALUE",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18044,
+          "description": "Fuel Needed Value",
+          "mask": 65535,
+          "max_value": 65000,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "Indicator Lights": {
+    "ATT_LAMP": {
+      "category": "Indicator Lights",
+      "control_type": "led",
+      "description": "ATT Lamp",
+      "identifier": "ATT_LAMP",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17944,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 2048,
+          "max_value": 1,
+          "shift_by": 11,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "HOJD_LAMP": {
+      "category": "Indicator Lights",
+      "control_type": "led",
+      "description": "HOJD Lamp",
+      "identifier": "HOJD_LAMP",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17944,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 4096,
+          "max_value": 1,
+          "shift_by": 12,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "SPAK_LAMP": {
+      "category": "Indicator Lights",
+      "control_type": "led",
+      "description": "SPAK Lamp",
+      "identifier": "SPAK_LAMP",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17944,
+          "description": "0 if light is off, 1 if light is on",
+          "mask": 1024,
+          "max_value": 1,
+          "shift_by": 10,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "Lights": {
+    "ANTI_COLLISION_LIGHTS": {
+      "category": "Lights",
+      "control_type": "selector",
+      "description": "Anti Collision Lights",
+      "identifier": "ANTI_COLLISION_LIGHTS",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17924,
+          "description": "selector position",
+          "mask": 16384,
+          "max_value": 1,
+          "shift_by": 14,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "EMERGENCY_LIGHTS": {
+      "category": "Lights",
+      "control_type": "selector",
+      "description": "Emergency Lights",
+      "identifier": "EMERGENCY_LIGHTS",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17926,
+          "description": "selector position",
+          "mask": 16,
+          "max_value": 1,
+          "shift_by": 4,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "FLOOD_LIGHTS": {
+      "category": "Lights",
+      "control_type": "limited_dial",
+      "description": "Flood Lights",
+      "identifier": "FLOOD_LIGHTS",
+      "inputs": [
+        {
+          "description": "set the position of the dial",
+          "interface": "set_state",
+          "max_value": 65535
+        },
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 17928,
+          "description": "position of the potentiometer",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "FORMATION_LIGHTS": {
+      "category": "Lights",
+      "control_type": "selector",
+      "description": "Formation Lights",
+      "identifier": "FORMATION_LIGHTS",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17924,
+          "description": "selector position",
+          "mask": 32768,
+          "max_value": 1,
+          "shift_by": 15,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "INSTRUMENT_LIGHTS": {
+      "category": "Lights",
+      "control_type": "limited_dial",
+      "description": "Instrument Lights",
+      "identifier": "INSTRUMENT_LIGHTS",
+      "inputs": [
+        {
+          "description": "set the position of the dial",
+          "interface": "set_state",
+          "max_value": 65535
+        },
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 17932,
+          "description": "position of the potentiometer",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "NAVIGATION_LIGHTS": {
+      "category": "Lights",
+      "control_type": "selector",
+      "description": "Navigation Lights",
+      "identifier": "NAVIGATION_LIGHTS",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 2
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17926,
+          "description": "selector position",
+          "mask": 3,
+          "max_value": 2,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "PANEL_LIGHTS": {
+      "category": "Lights",
+      "control_type": "limited_dial",
+      "description": "Panel Lights",
+      "identifier": "PANEL_LIGHTS",
+      "inputs": [
+        {
+          "description": "set the position of the dial",
+          "interface": "set_state",
+          "max_value": 65535
+        },
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 17930,
+          "description": "position of the potentiometer",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "POSITION_LIGHTS": {
+      "category": "Lights",
+      "control_type": "selector",
+      "description": "Position Lights",
+      "identifier": "POSITION_LIGHTS",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17926,
+          "description": "selector position",
+          "mask": 4,
+          "max_value": 1,
+          "shift_by": 2,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "POSITION_LIGHTS_BRIGHTNESS": {
+      "category": "Lights",
+      "control_type": "selector",
+      "description": "Position Lights Brightness",
+      "identifier": "POSITION_LIGHTS_BRIGHTNESS",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 2
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17926,
+          "description": "selector position",
+          "mask": 96,
+          "max_value": 2,
+          "shift_by": 5,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "TAXI_LANDING_LIGHTS": {
+      "category": "Lights",
+      "control_type": "selector",
+      "description": "Taxi/Landing Lights",
+      "identifier": "TAXI_LANDING_LIGHTS",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17926,
+          "description": "selector position",
+          "mask": 8,
+          "max_value": 1,
+          "shift_by": 3,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    }
+  },
+  "Navigation": {
+    "DATAPANEL_KEY_0": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Datapanel Key 0",
+      "identifier": "DATAPANEL_KEY_0",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17922,
+          "description": "selector position",
+          "mask": 256,
+          "max_value": 1,
+          "shift_by": 8,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "DATAPANEL_KEY_1": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Datapanel Key 1",
+      "identifier": "DATAPANEL_KEY_1",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17922,
+          "description": "selector position",
+          "mask": 512,
+          "max_value": 1,
+          "shift_by": 9,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "DATAPANEL_KEY_2": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Datapanel Key 2",
+      "identifier": "DATAPANEL_KEY_2",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17922,
+          "description": "selector position",
+          "mask": 1024,
+          "max_value": 1,
+          "shift_by": 10,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "DATAPANEL_KEY_3": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Datapanel Key 3",
+      "identifier": "DATAPANEL_KEY_3",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17922,
+          "description": "selector position",
+          "mask": 2048,
+          "max_value": 1,
+          "shift_by": 11,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "DATAPANEL_KEY_4": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Datapanel Key 4",
+      "identifier": "DATAPANEL_KEY_4",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17922,
+          "description": "selector position",
+          "mask": 4096,
+          "max_value": 1,
+          "shift_by": 12,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "DATAPANEL_KEY_5": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Datapanel Key 5",
+      "identifier": "DATAPANEL_KEY_5",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17922,
+          "description": "selector position",
+          "mask": 8192,
+          "max_value": 1,
+          "shift_by": 13,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "DATAPANEL_KEY_6": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Datapanel Key 6",
+      "identifier": "DATAPANEL_KEY_6",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17922,
+          "description": "selector position",
+          "mask": 16384,
+          "max_value": 1,
+          "shift_by": 14,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "DATAPANEL_KEY_7": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Datapanel Key 7",
+      "identifier": "DATAPANEL_KEY_7",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17922,
+          "description": "selector position",
+          "mask": 32768,
+          "max_value": 1,
+          "shift_by": 15,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "DATAPANEL_KEY_8": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Datapanel Key 8",
+      "identifier": "DATAPANEL_KEY_8",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17924,
+          "description": "selector position",
+          "mask": 1,
+          "max_value": 1,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "DATAPANEL_KEY_9": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Datapanel Key 9",
+      "identifier": "DATAPANEL_KEY_9",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17924,
+          "description": "selector position",
+          "mask": 2,
+          "max_value": 1,
+          "shift_by": 1,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "NAV_SELECT_BTN_B1": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Navigation Selector Button B1",
+      "identifier": "NAV_SELECT_BTN_B1",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17924,
+          "description": "selector position",
+          "mask": 4,
+          "max_value": 1,
+          "shift_by": 2,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "NAV_SELECT_BTN_B2": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Navigation Selector Button B2",
+      "identifier": "NAV_SELECT_BTN_B2",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17924,
+          "description": "selector position",
+          "mask": 8,
+          "max_value": 1,
+          "shift_by": 3,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "NAV_SELECT_BTN_B3": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Navigation Selector Button B3",
+      "identifier": "NAV_SELECT_BTN_B3",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17924,
+          "description": "selector position",
+          "mask": 16,
+          "max_value": 1,
+          "shift_by": 4,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "NAV_SELECT_BTN_B4": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Navigation Selector Button B4",
+      "identifier": "NAV_SELECT_BTN_B4",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17924,
+          "description": "selector position",
+          "mask": 32,
+          "max_value": 1,
+          "shift_by": 5,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "NAV_SELECT_BTN_B5": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Navigation Selector Button B5",
+      "identifier": "NAV_SELECT_BTN_B5",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17924,
+          "description": "selector position",
+          "mask": 64,
+          "max_value": 1,
+          "shift_by": 6,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "NAV_SELECT_BTN_B6": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Navigation Selector Button B6",
+      "identifier": "NAV_SELECT_BTN_B6",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17924,
+          "description": "selector position",
+          "mask": 128,
+          "max_value": 1,
+          "shift_by": 7,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "NAV_SELECT_BTN_B7": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Navigation Selector Button B7",
+      "identifier": "NAV_SELECT_BTN_B7",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17924,
+          "description": "selector position",
+          "mask": 256,
+          "max_value": 1,
+          "shift_by": 8,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "NAV_SELECT_BTN_B8": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Navigation Selector Button B8",
+      "identifier": "NAV_SELECT_BTN_B8",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17924,
+          "description": "selector position",
+          "mask": 512,
+          "max_value": 1,
+          "shift_by": 9,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "NAV_SELECT_BTN_B9": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Navigation Selector Button B9",
+      "identifier": "NAV_SELECT_BTN_B9",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17924,
+          "description": "selector position",
+          "mask": 1024,
+          "max_value": 1,
+          "shift_by": 10,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "NAV_SELECT_BTN_BX": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Navigation Selector Button BX",
+      "identifier": "NAV_SELECT_BTN_BX",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17924,
+          "description": "selector position",
+          "mask": 2048,
+          "max_value": 1,
+          "shift_by": 11,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "NAV_SELECT_BTN_LS": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Navigation Selector Button LS",
+      "identifier": "NAV_SELECT_BTN_LS",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17924,
+          "description": "selector position",
+          "mask": 4096,
+          "max_value": 1,
+          "shift_by": 12,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "NAV_SELECT_BTN_L_MAL": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation",
+      "control_type": "selector",
+      "description": "Navigation Selector Button L MAL",
+      "identifier": "NAV_SELECT_BTN_L_MAL",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17924,
+          "description": "selector position",
+          "mask": 8192,
+          "max_value": 1,
+          "shift_by": 13,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    }
+  },
+  "Navigation Panel": {
+    "AJS37_NAV_INDICATOR_DATA_1": {
+      "category": "Navigation Panel",
+      "control_type": "display",
+      "description": "Navigataion Panel Data Digit 1",
+      "identifier": "AJS37_NAV_INDICATOR_DATA_1",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18082,
+          "description": "Navigataion Panel Data Digit 1",
+          "max_length": 1,
+          "suffix": "",
+          "type": "string"
+        }
+      ]
+    },
+    "AJS37_NAV_INDICATOR_DATA_2": {
+      "category": "Navigation Panel",
+      "control_type": "display",
+      "description": "Navigataion Panel Data Digit 2",
+      "identifier": "AJS37_NAV_INDICATOR_DATA_2",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18084,
+          "description": "Navigataion Panel Data Digit 2",
+          "max_length": 1,
+          "suffix": "",
+          "type": "string"
+        }
+      ]
+    },
+    "AJS37_NAV_INDICATOR_DATA_3": {
+      "category": "Navigation Panel",
+      "control_type": "display",
+      "description": "Navigataion Panel Data Digit 3",
+      "identifier": "AJS37_NAV_INDICATOR_DATA_3",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18086,
+          "description": "Navigataion Panel Data Digit 3",
+          "max_length": 1,
+          "suffix": "",
+          "type": "string"
+        }
+      ]
+    },
+    "AJS37_NAV_INDICATOR_DATA_4": {
+      "category": "Navigation Panel",
+      "control_type": "display",
+      "description": "Navigataion Panel Data Digit 4",
+      "identifier": "AJS37_NAV_INDICATOR_DATA_4",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18088,
+          "description": "Navigataion Panel Data Digit 4",
+          "max_length": 1,
+          "suffix": "",
+          "type": "string"
+        }
+      ]
+    },
+    "AJS37_NAV_INDICATOR_DATA_5": {
+      "category": "Navigation Panel",
+      "control_type": "display",
+      "description": "Navigataion Panel Data Digit 5",
+      "identifier": "AJS37_NAV_INDICATOR_DATA_5",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18090,
+          "description": "Navigataion Panel Data Digit 5",
+          "max_length": 1,
+          "suffix": "",
+          "type": "string"
+        }
+      ]
+    },
+    "AJS37_NAV_INDICATOR_DATA_6": {
+      "category": "Navigation Panel",
+      "control_type": "display",
+      "description": "Navigataion Panel Data Digit 6",
+      "identifier": "AJS37_NAV_INDICATOR_DATA_6",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18092,
+          "description": "Navigataion Panel Data Digit 6",
+          "max_length": 1,
+          "suffix": "",
+          "type": "string"
+        }
+      ]
+    },
+    "AJS37_DEST_INDICATOR_DATA_1": {
+      "category": "Navigation Panel",
+      "control_type": "display",
+      "description": "Destination Panel Data Digit 1",
+      "identifier": "AJS37_DEST_INDICATOR_DATA_1",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18094,
+          "description": "Destination Panel Data Digit 1",
+          "max_length": 1,
+          "suffix": "",
+          "type": "string"
+        }
+      ]
+    },
+    "AJS37_DEST_INDICATOR_DATA_2": {
+      "category": "Navigation Panel",
+      "control_type": "display",
+      "description": "Destination Panel Data Digit 2",
+      "identifier": "AJS37_DEST_INDICATOR_DATA_2",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18096,
+          "description": "Destination Panel Data Digit 2",
+          "max_length": 1,
+          "suffix": "",
+          "type": "string"
+        }
+      ]
+    },
+    "CK37_RENSA_CLEAR": {
+      "api_variant": "momentary_last_position",
+      "category": "Navigation Panel",
+      "control_type": "selector",
+      "description": "CK37 Rensa Clear",
+      "identifier": "CK37_RENSA_CLEAR",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17942,
+          "description": "selector position",
+          "mask": 32,
+          "max_value": 1,
+          "shift_by": 5,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "DATAPANEL_SELECTOR": {
+      "category": "Navigation Panel",
+      "control_type": "selector",
+      "description": "Datapanel Selector",
+      "identifier": "DATAPANEL_SELECTOR",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 6
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17942,
+          "description": "selector position",
+          "mask": 7,
+          "max_value": 6,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "DATA_IN_OUT": {
+      "category": "Navigation Panel",
+      "control_type": "selector",
+      "description": "Data In/Out",
+      "identifier": "DATA_IN_OUT",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17942,
+          "description": "selector position",
+          "mask": 8,
+          "max_value": 1,
+          "shift_by": 3,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "RENSA_BUTTON_COVER": {
+      "category": "Navigation Panel",
+      "control_type": "selector",
+      "description": "Rensa Button Cover",
+      "identifier": "RENSA_BUTTON_COVER",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17942,
+          "description": "selector position",
+          "mask": 16,
+          "max_value": 1,
+          "shift_by": 4,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    }
+  },
+  "RWR": {
+    "MASTER_VOL": {
+      "category": "RWR",
+      "control_type": "limited_dial",
+      "description": "Master Volume / Sidewinder Tone",
+      "identifier": "MASTER_VOL",
+      "inputs": [
+        {
+          "description": "set the position of the dial",
+          "interface": "set_state",
+          "max_value": 65535
+        },
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 18078,
+          "description": "position of the potentiometer",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "RADAR_WARN_SELECT": {
+      "category": "RWR",
+      "control_type": "selector",
+      "description": "Radar Warning Indication Selector",
+      "identifier": "RADAR_WARN_SELECT",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 2
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17942,
+          "description": "selector position",
+          "mask": 192,
+          "max_value": 2,
+          "shift_by": 6,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    }
+  },
+  "Radar": {
+    "ANTI_JAM_MODE": {
+      "category": "Radar",
+      "control_type": "selector",
+      "description": "Anti Jamming Mode (AS) Selector",
+      "identifier": "ANTI_JAM_MODE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 7
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17922,
+          "description": "selector position",
+          "mask": 7,
+          "max_value": 7,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "IFF_CODE": {
+      "category": "Radar",
+      "control_type": "selector",
+      "description": "IFF Code",
+      "identifier": "IFF_CODE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 10
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18066,
+          "description": "selector position",
+          "mask": 61440,
+          "max_value": 10,
+          "shift_by": 12,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "IFF_POWER": {
+      "category": "Radar",
+      "control_type": "selector",
+      "description": "IFF Power",
+      "identifier": "IFF_POWER",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 18066,
+          "description": "selector position",
+          "mask": 2048,
+          "max_value": 1,
+          "shift_by": 11,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "RADAR_BRIGHT": {
+      "category": "Radar",
+      "control_type": "limited_dial",
+      "description": "Radar Brightness",
+      "identifier": "RADAR_BRIGHT",
+      "inputs": [
+        {
+          "description": "set the position of the dial",
+          "interface": "set_state",
+          "max_value": 65535
+        },
+        {
+          "description": "turn the dial left or right",
+          "interface": "variable_step",
+          "max_value": 65535,
+          "suggested_step": 3200
+        }
+      ],
+      "outputs": [
+        {
+          "address": 18080,
+          "description": "position of the potentiometer",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "RADAR_GAIN": {
+      "category": "Radar",
+      "control_type": "selector",
+      "description": "Lin/Log Radar Gain Switch",
+      "identifier": "RADAR_GAIN",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17920,
+          "description": "selector position",
+          "mask": 16384,
+          "max_value": 1,
+          "shift_by": 14,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "RADAR_IFF_ID": {
+      "api_variant": "momentary_last_position",
+      "category": "Radar",
+      "control_type": "selector",
+      "description": "IFF Identification",
+      "identifier": "RADAR_IFF_ID",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17922,
+          "description": "selector position",
+          "mask": 64,
+          "max_value": 1,
+          "shift_by": 6,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "RADAR_IGNITION_COILS": {
+      "category": "Radar",
+      "control_type": "selector",
+      "description": "Ignition Coils",
+      "identifier": "RADAR_IGNITION_COILS",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17922,
+          "description": "selector position",
+          "mask": 32,
+          "max_value": 1,
+          "shift_by": 5,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "RADAR_MAINTENANCE_TEST": {
+      "category": "Radar",
+      "control_type": "selector",
+      "description": "Radar/EL Maintenance Test",
+      "identifier": "RADAR_MAINTENANCE_TEST",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17922,
+          "description": "selector position",
+          "mask": 16,
+          "max_value": 1,
+          "shift_by": 4,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "RADAR_PULSE_NORMAL_SHORT": {
+      "category": "Radar",
+      "control_type": "selector",
+      "description": "Pulse Normal/Short Switch",
+      "identifier": "RADAR_PULSE_NORMAL_SHORT",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17920,
+          "description": "selector position",
+          "mask": 32768,
+          "max_value": 1,
+          "shift_by": 15,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "RADAR_RECCE_ON_OFF": {
+      "category": "Radar",
+      "control_type": "selector",
+      "description": "Passive Recce On/Off Switch",
+      "identifier": "RADAR_RECCE_ON_OFF",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17922,
+          "description": "selector position",
+          "mask": 8,
+          "max_value": 1,
+          "shift_by": 3,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    }
+  },
+  "Radar Altimeter": {
+    "RADAR_ALTIMETER_POWER": {
+      "category": "Radar Altimeter",
+      "control_type": "selector",
+      "description": "Radar Altimeter Power",
+      "identifier": "RADAR_ALTIMETER_POWER",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17936,
+          "description": "selector position",
+          "mask": 1,
+          "max_value": 1,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    }
+  },
+  "Raw Gauge Values": {
+    "ADI_AOA_INDICATOR": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "ADI AoA Indicator",
+      "identifier": "ADI_AOA_INDICATOR",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18004,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ADI_HEADING": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "ADI Heading",
+      "identifier": "ADI_HEADING",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17992,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ADI_HORIZONTAL_ILS": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "ADI Horizontal ILS",
+      "identifier": "ADI_HORIZONTAL_ILS",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18000,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ADI_PITCH": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "ADI Pitch",
+      "identifier": "ADI_PITCH",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17990,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ADI_ROLL": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "ADI Roll",
+      "identifier": "ADI_ROLL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17994,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ADI_SLIPBALL": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "ADI Slipball",
+      "identifier": "ADI_SLIPBALL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18002,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ADI_VERTICAL_ILS": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "ADI Vertical ILS",
+      "identifier": "ADI_VERTICAL_ILS",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17998,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ADI_VERTICAL_VELOCITY": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "ADI Vertical Velocity",
+      "identifier": "ADI_VERTICAL_VELOCITY",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17996,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "AIRSPEED_M/S": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Airspeed m/s",
+      "identifier": "AIRSPEED_M/S",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17968,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ALTIMETER_10000M": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Altimeter 10000 Meter",
+      "identifier": "ALTIMETER_10000M",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17978,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ALTIMETER_1000M": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Altimeter 1000 Meter",
+      "identifier": "ALTIMETER_1000M",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17980,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ALTIMETER_BARO_1000_HPA": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Altimeter Baro 1000 hPa X000",
+      "identifier": "ALTIMETER_BARO_1000_HPA",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17988,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ALTIMETER_BARO_100_HPA": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Altimeter Baro 100 hPa 0X00",
+      "identifier": "ALTIMETER_BARO_100_HPA",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17986,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ALTIMETER_BARO_10_HPA": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Altimeter Baro 10 hPa 00X0",
+      "identifier": "ALTIMETER_BARO_10_HPA",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17984,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ALTIMETER_BARO_1_HPA": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Altimeter Baro 1 hPa 000X",
+      "identifier": "ALTIMETER_BARO_1_HPA",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17982,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "BACKUP_ALTIMETER_10000M": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Backup Altimeter 10000 Meter",
+      "identifier": "BACKUP_ALTIMETER_10000M",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18014,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "BACKUP_ALTIMETER_1000M": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Backup Altimeter 1000 Meter",
+      "identifier": "BACKUP_ALTIMETER_1000M",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18016,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "BACKUP_INDICATED_AIRSPEED": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Backup Indicated Airspeed",
+      "identifier": "BACKUP_INDICATED_AIRSPEED",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18012,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "BACKUP_PITCH": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Backup Pitch",
+      "identifier": "BACKUP_PITCH",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18018,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "BACKUP_ROLL": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Backup Roll",
+      "identifier": "BACKUP_ROLL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18020,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "CI_COMMANDED_HEADING": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "CI Commanded Heading",
+      "identifier": "CI_COMMANDED_HEADING",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18008,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "CI_HEADING": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "CI Heading",
+      "identifier": "CI_HEADING",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18006,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "DISTANCE_INDICATOR": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Distance Indicator",
+      "identifier": "DISTANCE_INDICATOR",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18022,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ENGINE_RPM_10": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Engine RPM 10",
+      "identifier": "ENGINE_RPM_10",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17964,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ENGINE_RPM_100": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Engine RPM 100",
+      "identifier": "ENGINE_RPM_100",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17962,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "ENGINE_TEMP": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Engine Temp",
+      "identifier": "ENGINE_TEMP",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17966,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "FUEL_LEVEL": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Fuel Level",
+      "identifier": "FUEL_LEVEL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18024,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "FUEL_NEEDED": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Fuel Needed",
+      "identifier": "FUEL_NEEDED",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18026,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "MACH_METER_FIRST_DECIMAL": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Mach Meter First Decimal 0.X0",
+      "identifier": "MACH_METER_FIRST_DECIMAL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17972,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "MACH_METER_INTEGER": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Mach Meter Integer X.00",
+      "identifier": "MACH_METER_INTEGER",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17970,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "MACH_METER_SECOND_DECIMAL": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Mach Meter Second Decimal 0.0X",
+      "identifier": "MACH_METER_SECOND_DECIMAL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17974,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "MAGNETIC_HEADING": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Magnetic Heading",
+      "identifier": "MAGNETIC_HEADING",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 18010,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "PEDALS": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Pedals",
+      "identifier": "PEDALS",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17958,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "STICK_PITCH": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Stick Pitch",
+      "identifier": "STICK_PITCH",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17954,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "STICK_ROLL": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Stick Roll",
+      "identifier": "STICK_ROLL",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17956,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "THROTTLE": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Throttle",
+      "identifier": "THROTTLE",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17960,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    },
+    "VERTICAL_ACCELERATION": {
+      "category": "Raw Gauge Values",
+      "control_type": "analog_gauge",
+      "description": "Vertical Acceleration G Meter",
+      "identifier": "VERTICAL_ACCELERATION",
+      "inputs": [],
+      "outputs": [
+        {
+          "address": 17976,
+          "description": "gauge position",
+          "mask": 65535,
+          "max_value": 65535,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "Thrust Reverser": {
+    "REVERSAL": {
+      "category": "Thrust Reverser",
+      "control_type": "selector",
+      "description": "Thrust Reverser On/Off",
+      "identifier": "REVERSAL",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17922,
+          "description": "selector position",
+          "mask": 128,
+          "max_value": 1,
+          "shift_by": 7,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    }
+  },
+  "Warning Panel": {
+    "INDICATOR_SYSTEM_TEST": {
+      "api_variant": "momentary_last_position",
+      "category": "Warning Panel",
+      "control_type": "selector",
+      "description": "Indicator System Test",
+      "identifier": "INDICATOR_SYSTEM_TEST",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17942,
+          "description": "selector position",
+          "mask": 512,
+          "max_value": 1,
+          "shift_by": 9,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "MASTER_CAUTION_RESET": {
+      "category": "Warning Panel",
+      "control_type": "selector",
+      "description": "Master Caution Reset",
+      "identifier": "MASTER_CAUTION_RESET",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17942,
+          "description": "selector position",
+          "mask": 1024,
+          "max_value": 1,
+          "shift_by": 10,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "WARNING_PANEL_TEST": {
+      "api_variant": "momentary_last_position",
+      "category": "Warning Panel",
+      "control_type": "selector",
+      "description": "Warning Panel Light Test",
+      "identifier": "WARNING_PANEL_TEST",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17942,
+          "description": "selector position",
+          "mask": 256,
+          "max_value": 1,
+          "shift_by": 8,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    }
+  },
+  "Weapon System": {
+    "RB_BK_REL_MODE": {
+      "category": "Weapon System",
+      "control_type": "selector",
+      "description": "RB-04/RB-15/BK Release Mode Switch",
+      "identifier": "RB_BK_REL_MODE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17920,
+          "description": "selector position",
+          "mask": 8192,
+          "max_value": 1,
+          "shift_by": 13,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "TANK_RELEASE": {
+      "api_variant": "momentary_last_position",
+      "category": "Weapon System",
+      "control_type": "selector",
+      "description": "External Tank Release Button",
+      "identifier": "TANK_RELEASE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17920,
+          "description": "selector position",
+          "mask": 16,
+          "max_value": 1,
+          "shift_by": 4,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "TANK_RELEASE_COVER": {
+      "category": "Weapon System",
+      "control_type": "selector",
+      "description": "External Tank Release Cover",
+      "identifier": "TANK_RELEASE_COVER",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17920,
+          "description": "selector position",
+          "mask": 8,
+          "max_value": 1,
+          "shift_by": 3,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "TRIGGER_SAFETY_BRACKET": {
+      "category": "Weapon System",
+      "control_type": "selector",
+      "description": "Trigger Safety Bracket",
+      "identifier": "TRIGGER_SAFETY_BRACKET",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17920,
+          "description": "selector position",
+          "mask": 1,
+          "max_value": 1,
+          "shift_by": 0,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "WEAPON_INTERVAL": {
+      "category": "Weapon System",
+      "control_type": "selector",
+      "description": "Weapon Interval Selector Mode Knob",
+      "identifier": "WEAPON_INTERVAL",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 10
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17920,
+          "description": "selector position",
+          "mask": 3840,
+          "max_value": 10,
+          "shift_by": 8,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    },
+    "WEAPON_RELEASE": {
+      "api_variant": "momentary_last_position",
+      "category": "Weapon System",
+      "control_type": "selector",
+      "description": "Weapon Emergency Release Button",
+      "identifier": "WEAPON_RELEASE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17920,
+          "description": "selector position",
+          "mask": 4,
+          "max_value": 1,
+          "shift_by": 2,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "push_button"
+    },
+    "WEAPON_RELEASE_COVER": {
+      "category": "Weapon System",
+      "control_type": "selector",
+      "description": "Weapon Emergency Release Cover",
+      "identifier": "WEAPON_RELEASE_COVER",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17920,
+          "description": "selector position",
+          "mask": 2,
+          "max_value": 1,
+          "shift_by": 1,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "WEAPON_REL_MODE": {
+      "category": "Weapon System",
+      "control_type": "selector",
+      "description": "Weapon Release Mode Switch",
+      "identifier": "WEAPON_REL_MODE",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 1
+        },
+        {
+          "argument": "TOGGLE",
+          "description": "Toggle switch state",
+          "interface": "action"
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17920,
+          "description": "selector position",
+          "mask": 4096,
+          "max_value": 1,
+          "shift_by": 12,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "toggle_switch"
+    },
+    "WEAPON_SELECT": {
+      "category": "Weapon System",
+      "control_type": "selector",
+      "description": "Weapon Selector Knob",
+      "identifier": "WEAPON_SELECT",
+      "inputs": [
+        {
+          "description": "switch to previous or next state",
+          "interface": "fixed_step"
+        },
+        {
+          "description": "set position",
+          "interface": "set_state",
+          "max_value": 5
+        }
+      ],
+      "momentary_positions": "none",
+      "outputs": [
+        {
+          "address": 17920,
+          "description": "selector position",
+          "mask": 224,
+          "max_value": 5,
+          "shift_by": 5,
+          "suffix": "",
+          "type": "integer"
+        }
+      ],
+      "physical_variant": "limited_rotary"
+    }
+  }
 }

--- a/AJS37.lua
+++ b/AJS37.lua
@@ -487,7 +487,37 @@ end
  
 defineString("AJS37_NAV_INDICATOR_DATA_6", getAJS37NavIndicator6, 1, "Navigation Panel", "Navigataion Panel Data Digit 6")
 
+local function getAJS37DestIndicator1()
+	local li = list_indication(1)
+	local m = li:gmatch("-----------------------------------------\n([^\n]+)\n([^\n]*)\n")
+	while true do
+		local name, value = m()
+        if not name then break end
+		if name == "Dest1"
+			then
+			return value:sub(1)
+		end
+    end
+return ""
+end
+ 
+defineString("AJS37_DEST_INDICATOR_DATA_1", getAJS37DestIndicator1, 1, "Navigation Panel", "Destination Panel Data Digit 1")
 
+local function getAJS37DestIndicator2()
+	local li = list_indication(1)
+	local m = li:gmatch("-----------------------------------------\n([^\n]+)\n([^\n]*)\n")
+	while true do
+		local name, value = m()
+        if not name then break end
+		if name == "Dest2"
+			then
+			return value:sub(1)
+		end
+    end
+return ""
+end
+ 
+defineString("AJS37_DEST_INDICATOR_DATA_2", getAJS37DestIndicator2, 1, "Navigation Panel", "Destination Panel Data Digit 2")
 
 
 BIOS.protocol.endModule()


### PR DESCRIPTION
I noticed the values of the destination display were not included in the module.
![image](https://user-images.githubusercontent.com/6606939/104058785-93e41300-51f4-11eb-9009-077b1db7312e.png)
The values can be accessed just like the data panel values and should therefore work without problems. 
